### PR TITLE
Restart Wrappers & Separable CMA-ES

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ state["best_member"], state["best_fitness"]
 | PGPE | [Sehnke et al. (2010)](https://citeseerx.ist.psu.edu/viewdoc/download;jsessionid=A64D1AE8313A364B814998E9E245B40A?doi=10.1.1.180.7104&rep=rep1&type=pdf) | [`PGPE_ES`](https://github.com/RobertTLange/evosax/tree/main/evosax/strategies/pgpe_es.py)  | [![Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/RobertTLange/evosax/blob/main/examples/02_mlp_control.ipynb)
 | ARS | [Mania et al. (2018)](https://arxiv.org/pdf/1803.07055.pdf) | [`Augmented_RS`](https://github.com/RobertTLange/evosax/tree/main/evosax/strategies/ars.py)  | [![Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/RobertTLange/evosax/blob/main/examples/00_getting_started.ipynb)
 | CMA-ES | [Hansen (2016)](https://arxiv.org/abs/1604.00772) | [`CMA_ES`](https://github.com/RobertTLange/evosax/tree/main/evosax/strategies/cma_es.py) | [![Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/RobertTLange/evosax/blob/main/examples/01_classic_benchmark.ipynb)
+| Separable CMA-ES | [Ros & Hansen (2008)](https://hal.inria.fr/inria-00287367/document) | [`Sep_CMA_ES`](https://github.com/RobertTLange/evosax/tree/main/evosax/strategies/sep_cma_es.py)  | [![Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/RobertTLange/evosax/blob/main/examples/01_classic_benchmark.ipynb)
 | Simple Gaussian | [Rechenberg (1975)](https://onlinelibrary.wiley.com/doi/abs/10.1002/fedr.19750860506) | [`Simple_ES`](https://github.com/RobertTLange/evosax/tree/main/evosax/strategies/simple_es.py) | [![Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/RobertTLange/evosax/blob/main/examples/01_classic_benchmark.ipynb)
 | Simple Genetic | [Such et al. (2017)](https://arxiv.org/abs/1712.06567) | [`Simple_GA`](https://github.com/RobertTLange/evosax/tree/main/evosax/strategies/simple_ga.py) | [![Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/RobertTLange/evosax/blob/main/examples/01_classic_benchmark.ipynb)
 | x-NES | [Wierstra et al. (2014)](https://www.jmlr.org/papers/volume15/wierstra14a/wierstra14a.pdf) | [`xNES`](https://github.com/RobertTLange/evosax/tree/main/evosax/strategies/xnes.py)  | [![Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/RobertTLange/evosax/blob/main/examples/01_classic_benchmark.ipynb)
@@ -160,10 +161,11 @@ fit_shaped = fit_shaper.apply(x, fitness)
 ```
 
 
-## References & Other Great JAX-ES Tools 📝
+## Resources & Other Great JAX-ES Tools 📝
+* 📺 [Rob's MLC Research Jam Talk](https://www.youtube.com/watch?v=Wn6Lq2bexlA&t=51s): Small motivation talk at the ML Collective Research Jam.
+* 📝 [Rob's 02/2021 Blog](https://roberttlange.github.io/posts/2021/02/cma-es-jax/): Tutorial on CMA-ES & leveraging JAX's primitives.
 * 💻 [Evojax](https://github.com/google/evojax): JAX-ES library by Google Brain with great rollout wrappers.
 * 💻 [QDax](https://github.com/adaptive-intelligent-robotics/QDax): Quality-Diversity algorithms in JAX.
-* 💻 [Rob's Blog](https://roberttlange.github.io/posts/2021/02/cma-es-jax/): Tutorial on CMA-ES & leveraging JAX's primitives.
 
 ## Development 👷
 

--- a/evosax/__init__.py
+++ b/evosax/__init__.py
@@ -11,6 +11,7 @@ from .strategies import (
     Persistent_ES,
     xNES,
     Augmented_RS,
+    Sep_CMA_ES,
 )
 
 
@@ -26,6 +27,7 @@ Strategies = {
     "Persistent_ES": Persistent_ES,
     "xNES": xNES,
     "Augmented_RS": Augmented_RS,
+    "Sep_CMA_ES": Sep_CMA_ES,
 }
 
 from .utils import FitnessShaper, ParameterReshaper, ESLog
@@ -45,6 +47,7 @@ __all__ = [
     "Persistent_ES",
     "xNES",
     "Augmented_RS",
+    "Sep_CMA_ES",
     "Strategies",
     "FitnessShaper",
     "ParameterReshaper",

--- a/evosax/problems/control_brax.py
+++ b/evosax/problems/control_brax.py
@@ -71,9 +71,9 @@ class BraxFitness(object):
         if self.n_devices > 1:
             self.rollout_map = self.rollout_pmap
             print(
-                "More than one device detected. Please make sure that the ES"
-                " population size divides evenly across the number of devices"
-                " to pmap/parallelize over."
+                "BraxFitness: More than one device detected. Please make sure"
+                " that the ES population size divides evenly across the number"
+                " of devices to pmap/parallelize over."
             )
         else:
             self.rollout_map = self.rollout_pop

--- a/evosax/problems/control_gym.py
+++ b/evosax/problems/control_gym.py
@@ -48,9 +48,9 @@ class GymFitness(object):
         if self.n_devices > 1:
             self.rollout_map = self.rollout_pmap
             print(
-                "More than one device detected. Please make sure that the ES"
-                " population size divides evenly across the number of devices"
-                " to pmap/parallelize over."
+                "GymFitness: More than one device detected. Please make sure"
+                " that the ES population size divides evenly across the number"
+                " of devices to pmap/parallelize over."
             )
         else:
             self.rollout_map = self.rollout_pop

--- a/evosax/problems/supervised.py
+++ b/evosax/problems/supervised.py
@@ -31,9 +31,9 @@ class SupervisedFitness(object):
         if self.n_devices > 1:
             self.rollout = self.rollout_pmap
             print(
-                "More than one device detected. Please make sure that the ES"
-                " population size divides evenly across the number of devices"
-                " to pmap/parallelize over."
+                "SupervisedFitness: More than one device detected. Please make"
+                " sure that the ES population size divides evenly across the"
+                " number of devices to pmap/parallelize over."
             )
         else:
             self.rollout = jax.jit(self.rollout_pop)

--- a/evosax/restarts/__init__.py
+++ b/evosax/restarts/__init__.py
@@ -1,4 +1,5 @@
 from .simple_restart import Simple_Restarter
+from .bipop_restart import BIPOP_Restarter
 
 
-__all__ = ["Simple_Restarter"]
+__all__ = ["Simple_Restarter", "BIPOP_Restarter"]

--- a/evosax/restarts/__init__.py
+++ b/evosax/restarts/__init__.py
@@ -1,0 +1,4 @@
+from .simple_restart import Simple_Restarter
+
+
+__all__ = ["Simple_Restarter"]

--- a/evosax/restarts/bipop_restart.py
+++ b/evosax/restarts/bipop_restart.py
@@ -1,0 +1,99 @@
+import jax
+import chex
+from functools import partial
+from typing import Tuple
+from .restarter import RestartWrapper
+from .termination import spread_criterion
+from .. import Strategies
+
+
+class BIPOP_Restarter(RestartWrapper):
+    def __init__(
+        self,
+        base_strategy,
+        stop_criteria=[spread_criterion],
+    ):
+        super().__init__(base_strategy, stop_criteria)
+        self.default_popsize = self.base_strategy.popsize
+
+    @property
+    def restart_params(self) -> chex.ArrayTree:
+        """Return default parameters for strategy restarting."""
+        re_params = {
+            "min_num_gens": 50,
+            "min_fitness_spread": 0.1,
+            "popsize_multiplier": 2,
+        }
+        return re_params
+
+    @partial(jax.jit, static_argnums=(0,))
+    def initialize(
+        self, rng: chex.PRNGKey, params: chex.ArrayTree
+    ) -> chex.ArrayTree:
+        """`initialize` the evolution strategy."""
+        state = self.base_strategy.initialize(rng, params)
+        state["restart_counter"] = 0
+        state["restarted"] = False
+
+        # Add BIPOP-specific state elements to PyTree
+        state["restart_large_counter"] = 0
+        state["active_popsize"] = self.base_strategy.popsize
+        state["large_eval_budget"] = 0
+        state["small_eval_budget"] = 0
+        state["small_pop_active"] = True
+        return state
+
+    def ask(
+        self, rng: chex.PRNGKey, state: chex.ArrayTree, params: chex.ArrayTree
+    ) -> Tuple[chex.Array, chex.ArrayTree]:
+        """`ask` for new parameter candidates to evaluate next."""
+        self.base_strategy = Strategies[self.base_strategy.strategy_name](
+            popsize=state["active_popsize"], num_dims=self.num_dims
+        )
+        x, state = self.base_strategy.ask(rng, state, params)
+        return x, state
+
+    def restart_strategy(
+        self,
+        rng: chex.PRNGKey,
+        fitness: chex.Array,
+        state: chex.ArrayTree,
+        params: chex.ArrayTree,
+    ) -> chex.ArrayTree:
+        """Reinstantiate a new strategy with interlaced population sizes."""
+        # Track number of evals depending on active population
+        large_eval_budget = jax.lax.select(
+            state["small_pop_active"],
+            state["large_eval_budget"],
+            state["large_eval_budget"]
+            + state["active_popsize"] * state["gen_counter"],
+        )
+        small_eval_budget = jax.lax.select(
+            state["small_pop_active"],
+            state["small_eval_budget"]
+            + state["active_popsize"] * state["gen_counter"],
+            state["small_eval_budget"],
+        )
+        small_pop_active = small_eval_budget < large_eval_budget
+
+        # Update the population size based on active population size
+        pop_mult = params["popsize_multiplier"] ** (
+            state["restart_large_counter"] + 1
+        )
+        small_popsize = jax.lax.floor(
+            self.default_popsize * pop_mult ** (jax.random.uniform(rng) ** 2)
+        ).astype(int)
+        large_popsize = self.default_popsize * pop_mult
+
+        # Reinstantiate new strategy - based on name of previous strategy
+        re_state = self.base_strategy.initialize(rng, params)
+        re_state["small_pop_active"] = small_pop_active
+        re_state["large_eval_budget"] = large_eval_budget
+        re_state["small_eval_budget"] = small_eval_budget
+        re_state["active_popsize"] = jax.lax.select(
+            small_pop_active, small_popsize, large_popsize
+        )
+        re_state["restart_large_counter"] = (
+            state["restart_large_counter"] + 1 - small_pop_active
+        )
+        return re_state

--- a/evosax/restarts/bipop_restart.py
+++ b/evosax/restarts/bipop_restart.py
@@ -13,6 +13,9 @@ class BIPOP_Restarter(RestartWrapper):
         base_strategy,
         stop_criteria=[spread_criterion],
     ):
+        """Bi-Population Restarts (Hansen, 2009) - Interlaced population sizes.
+        Reference: https://hal.inria.fr/inria-00382093/document
+        Inspired by: https://tinyurl.com/44y3ryhf"""
         super().__init__(base_strategy, stop_criteria)
         self.default_popsize = self.base_strategy.popsize
 
@@ -47,6 +50,7 @@ class BIPOP_Restarter(RestartWrapper):
         self, rng: chex.PRNGKey, state: chex.ArrayTree, params: chex.ArrayTree
     ) -> Tuple[chex.Array, chex.ArrayTree]:
         """`ask` for new parameter candidates to evaluate next."""
+        # TODO: Cannot jit! Re-definition of strategy with different popsizes.
         self.base_strategy = Strategies[self.base_strategy.strategy_name](
             popsize=state["active_popsize"], num_dims=self.num_dims
         )

--- a/evosax/restarts/restarter.py
+++ b/evosax/restarts/restarter.py
@@ -1,0 +1,104 @@
+import jax
+import jax.numpy as jnp
+import chex
+from typing import Tuple
+from functools import partial
+from .termination import min_gen_criterion
+
+
+class RestartWrapper(object):
+    def __init__(self, base_strategy, stop_criteria=[]):
+        self.base_strategy = base_strategy
+        self.stop_criteria = stop_criteria
+
+    @property
+    def default_params(self) -> chex.ArrayTree:
+        """Return default parameters of evolution strategy."""
+        base_params = self.base_strategy.default_params
+        params = {**base_params, **self.restart_params}
+        return params
+
+    @property
+    def restart_params(self) -> chex.ArrayTree:
+        """Return default parameters for strategy restarting."""
+        re_params = {"min_num_gens": 50}
+        return re_params
+
+    @partial(jax.jit, static_argnums=(0,))
+    def initialize(
+        self, rng: chex.PRNGKey, params: chex.ArrayTree
+    ) -> chex.ArrayTree:
+        """`initialize` the evolution strategy."""
+        state = self.base_strategy.initialize(rng, params)
+        state["restart_counter"] = 0
+        state["restarted"] = False
+        return state
+
+    @partial(jax.jit, static_argnums=(0,))
+    def ask(
+        self, rng: chex.PRNGKey, state: chex.ArrayTree, params: chex.ArrayTree
+    ) -> Tuple[chex.Array, chex.ArrayTree]:
+        """`ask` for new parameter candidates to evaluate next."""
+        x, state = self.base_strategy.ask(rng, state, params)
+        return x, state
+
+    @partial(jax.jit, static_argnums=(0,))
+    def tell(
+        self,
+        rng: chex.PRNGKey,
+        x: chex.Array,
+        fitness: chex.Array,
+        state: chex.ArrayTree,
+        params: chex.ArrayTree,
+    ) -> chex.ArrayTree:
+        """`tell` performance data for strategy state update."""
+        state = self.base_strategy.tell(x, fitness, state, params)
+        restart_bool = self.stop(fitness, state, params)
+        restart_state = self.restart(rng, fitness, state, params)
+        new_state = jax.tree_multimap(
+            lambda x, y: jax.lax.select(restart_bool, x, y),
+            restart_state,
+            state,
+        )
+        return new_state
+
+    @partial(jax.jit, static_argnums=(0,))
+    def stop(
+        self, fitness: chex.Array, state: chex.ArrayTree, params: chex.ArrayTree
+    ) -> bool:
+        """Check all stopping criteria & return stopping bool indicator."""
+        restart_bool = 0
+        # Loop over stop criteria functions - stop if one is fullfilled
+        for crit in self.stop_criteria:
+            restart_bool += crit(fitness, state, params)
+        # Check if minimal number of generations has passed!
+        return jnp.logical_and(
+            restart_bool > 0, min_gen_criterion(fitness, state, params)
+        )
+
+    @partial(jax.jit, static_argnums=(0,))
+    def restart(
+        self,
+        rng: chex.PRNGKey,
+        fitness: chex.Array,
+        state: chex.ArrayTree,
+        params: chex.ArrayTree,
+    ) -> chex.ArrayTree:
+        """Restart state for next generations."""
+        new_state = self.restart_strategy(rng, fitness, state, params)
+        # Copy over important parts of state from previous strategy
+        new_state["best_fitness"] = state["best_fitness"]
+        new_state["best_member"] = state["best_member"]
+        new_state["restart_counter"] = state["restart_counter"] + 1
+        new_state["restarted"] = True
+        return new_state
+
+    def restart_strategy(
+        self,
+        rng: chex.PRNGKey,
+        fitness: chex.Array,
+        state: chex.ArrayTree,
+        params: chex.ArrayTree,
+    ) -> chex.ArrayTree:
+        """Restart strategy specific new state construction."""
+        raise NotImplementedError

--- a/evosax/restarts/restarter.py
+++ b/evosax/restarts/restarter.py
@@ -12,6 +12,16 @@ class RestartWrapper(object):
         self.stop_criteria = stop_criteria
 
     @property
+    def num_dims(self) -> int:
+        """Get number of problem dimensions from base strategy."""
+        return self.base_strategy.num_dims
+
+    @property
+    def popsize(self) -> int:
+        """Get population size from base strategy."""
+        return self.base_strategy.popsize
+
+    @property
     def default_params(self) -> chex.ArrayTree:
         """Return default parameters of evolution strategy."""
         base_params = self.base_strategy.default_params
@@ -60,6 +70,7 @@ class RestartWrapper(object):
             restart_state,
             state,
         )
+        new_state["restarted"] = restart_bool
         return new_state
 
     @partial(jax.jit, static_argnums=(0,))
@@ -76,7 +87,6 @@ class RestartWrapper(object):
             restart_bool > 0, min_gen_criterion(fitness, state, params)
         )
 
-    @partial(jax.jit, static_argnums=(0,))
     def restart(
         self,
         rng: chex.PRNGKey,

--- a/evosax/restarts/restarter.py
+++ b/evosax/restarts/restarter.py
@@ -8,6 +8,7 @@ from .termination import min_gen_criterion
 
 class RestartWrapper(object):
     def __init__(self, base_strategy, stop_criteria=[]):
+        """Base Class for a Restart Strategy."""
         self.base_strategy = base_strategy
         self.stop_criteria = stop_criteria
 

--- a/evosax/restarts/simple_restart.py
+++ b/evosax/restarts/simple_restart.py
@@ -1,0 +1,24 @@
+import chex
+from .restarter import RestartWrapper
+from .termination import spread_criterion
+
+
+class Simple_Restarter(RestartWrapper):
+    def __init__(self, base_strategy, stop_criteria=[spread_criterion]):
+        super().__init__(base_strategy, stop_criteria)
+
+    @property
+    def restart_params(self) -> chex.ArrayTree:
+        """Return default parameters for strategy restarting."""
+        re_params = {"min_num_gens": 50, "min_fitness_spread": 0.1}
+        return re_params
+
+    def restart_strategy(
+        self,
+        rng: chex.PRNGKey,
+        fitness: chex.Array,
+        state: chex.ArrayTree,
+        params: chex.ArrayTree,
+    ) -> chex.ArrayTree:
+        re_state = self.base_strategy.initialize(rng, params)
+        return re_state

--- a/evosax/restarts/simple_restart.py
+++ b/evosax/restarts/simple_restart.py
@@ -5,6 +5,7 @@ from .termination import spread_criterion
 
 class Simple_Restarter(RestartWrapper):
     def __init__(self, base_strategy, stop_criteria=[spread_criterion]):
+        """Simple Restart Strategy - Only reinitialize the state."""
         super().__init__(base_strategy, stop_criteria)
 
     @property
@@ -20,5 +21,6 @@ class Simple_Restarter(RestartWrapper):
         state: chex.ArrayTree,
         params: chex.ArrayTree,
     ) -> chex.ArrayTree:
+        """Simple restart by state initialization."""
         re_state = self.base_strategy.initialize(rng, params)
         return re_state

--- a/evosax/restarts/termination.py
+++ b/evosax/restarts/termination.py
@@ -1,0 +1,64 @@
+import chex
+import jax.numpy as jnp
+
+
+def min_gen_criterion(
+    fitness: chex.Array, state: chex.ArrayTree, params: chex.ArrayTree
+) -> bool:
+    """Allow stopping if minimal number of generations has passed."""
+    min_gen_passed = state["gen_counter"] >= params["min_num_gens"]
+    return min_gen_passed
+
+
+def spread_criterion(
+    fitness: chex.Array, state: chex.ArrayTree, params: chex.ArrayTree
+) -> bool:
+    """Stop if min/max fitness spread of recent generation is below thresh."""
+    fit_var_too_low = (
+        jnp.max(fitness) - jnp.min(fitness) < params["min_fitness_spread"]
+    )
+    return fit_var_too_low
+
+
+# def cma_criterion(
+#     fitness: chex.Array, state: chex.ArrayTree, params: chex.ArrayTree
+# ):
+#     """Check whether to terminate CMA-ES loop."""
+#     dC = jnp.diag(state["C"])
+#     C, B, D = eigen_decomposition(state["C"], state["B"], state["D"])
+
+#     # Stop if std of normal distrib is smaller than tolx in all coordinates
+#     # and pc is smaller than tolx in all components.
+#     if jnp.all(state["sigma"] * dC < params["tol_x"]) and np.all(
+#         state["sigma"] * state["p_c"] < params["tol_x"]
+#     ):
+#         print("TERMINATE ----> Convergence/Search variance too small")
+#         return True
+
+#     # Stop if detecting divergent behavior.
+#     if state["sigma"] * jnp.max(D) > params["tol_x_up"]:
+#         print("TERMINATE ----> Stepsize sigma exploded")
+#         return True
+
+#     # No effect coordinates: stop if adding 0.2-standard deviations
+#     # in any single coordinate does not change m.
+#     if jnp.any(
+#         state["mean"] == state["mean"] + (0.2 * state["sigma"] * jnp.sqrt(dC))
+#     ):
+#         print("TERMINATE ----> No effect when adding std to mean")
+#         return True
+
+#     # No effect axis: stop if adding 0.1-standard deviation vector in
+#     # any principal axis direction of C does not change m.
+#     if jnp.all(
+#         state["mean"] == state["mean"] + (0.1 * state["sigma"] * D[0] * B[:, 0])
+#     ):
+#         print("TERMINATE ----> No effect when adding std to mean")
+#         return True
+
+#     # Stop if the condition number of the covariance matrix exceeds 1e14.
+#     condition_cov = jnp.max(D) / jnp.min(D)
+#     if condition_cov > params["tol_condition_C"]:
+#         print("TERMINATE ----> C condition number exploded")
+#         return True
+#     return False

--- a/evosax/strategies/__init__.py
+++ b/evosax/strategies/__init__.py
@@ -9,6 +9,7 @@ from .pbt_es import PBT_ES
 from .persistent_es import Persistent_ES
 from .xnes import xNES
 from .ars import Augmented_RS
+from .sep_cma_es import Sep_CMA_ES
 
 
 __all__ = [
@@ -23,4 +24,5 @@ __all__ = [
     "Persistent_ES",
     "xNES",
     "Augmented_RS",
+    "Sep_CMA_ES",
 ]

--- a/evosax/strategies/ars.py
+++ b/evosax/strategies/ars.py
@@ -25,6 +25,7 @@ class Augmented_RS(Strategy):
         self.elite_popsize = int(self.popsize / 2 * self.elite_ratio)
         assert opt_name in ["sgd", "adam", "rmsprop", "clipup"]
         self.optimizer = GradientOptimizer[opt_name](self.num_dims)
+        self.strategy_name = "Augmented_RS"
 
     @property
     def params_strategy(self) -> chex.ArrayTree:

--- a/evosax/strategies/cma_es.py
+++ b/evosax/strategies/cma_es.py
@@ -77,13 +77,13 @@ class CMA_ES(Strategy):
             "mu_eff": mu_eff,
             "c_1": c_1,
             "c_mu": c_mu,
-            "c_m": 1,
+            "c_m": 1.0,
             "c_sigma": c_sigma,
             "d_sigma": d_sigma,
             "c_c": c_c,
             "chi_n": chi_n,
             "weights": weights,
-            "sigma_init": 1,
+            "sigma_init": 1.0,
             "weights_truncated": weights_truncated,
             "init_min": 0.0,
             "init_max": 0.0,
@@ -305,47 +305,3 @@ def eigen_decomposition(
 #     assert c_sigma < 1, "invalid lrate for cum. of step-size c."
 #     assert c_c <= 1, "invalid lrate for cum. of rank-one update"
 #     return
-#
-#
-# def check_termination(values, params, state):
-#     """ Check whether to terminate CMA-ES loop. """
-#     dC = jnp.diag(memory["C"])
-#     C, B, D = eigen_decomposition(memory["C"], memory["B"], memory["D"])
-#
-#     # Stop if generation fct values of recent generation is below thresh.
-#     if (memory["generation"] > params["min_generations"]
-#         and jnp.max(values) - jnp.min(values) < params["tol_fun"]):
-#         print("TERMINATE ----> Convergence/No progress in objective")
-#         return True
-#
-#     # Stop if std of normal distrib is smaller than tolx in all coordinates
-#     # and pc is smaller than tolx in all components.
-#     if jnp.all(memory["sigma"] * dC < params["tol_x"]) and np.all(
-#         memory["sigma"] * memory["p_c"] < params["tol_x"]):
-#         print("TERMINATE ----> Convergence/Search variance too small")
-#         return True
-#
-#     # Stop if detecting divergent behavior.
-#     if memory["sigma"] * jnp.max(D) > params["tol_x_up"]:
-#         print("TERMINATE ----> Stepsize sigma exploded")
-#         return True
-#
-#     # No effect coordinates: stop if adding 0.2-standard deviations
-#     # in any single coordinate does not change m.
-#     if jnp.any(memory["mean"] == memory["mean"] + (0.2 * memory["sigma"] * jnp.sqrt(dC))):
-#         print("TERMINATE ----> No effect when adding std to mean")
-#         return True
-#
-#     # No effect axis: stop if adding 0.1-standard deviation vector in
-#     # any principal axis direction of C does not change m.
-#     if jnp.all(memory["mean"] == memory["mean"] + (0.1 * memory["sigma"]
-#                                 * D[0] * B[:, 0])):
-#         print("TERMINATE ----> No effect when adding std to mean")
-#         return True
-#
-#     # Stop if the condition number of the covariance matrix exceeds 1e14.
-#     condition_cov = jnp.max(D) / jnp.min(D)
-#     if condition_cov > params["tol_condition_C"]:
-#         print("TERMINATE ----> C condition number exploded")
-#         return True
-#     return False

--- a/evosax/strategies/cma_es.py
+++ b/evosax/strategies/cma_es.py
@@ -14,6 +14,7 @@ class CMA_ES(Strategy):
         assert 0 <= elite_ratio <= 1
         self.elite_ratio = elite_ratio
         self.elite_popsize = int(self.popsize * self.elite_ratio)
+        self.strategy_name = "CMA_ES"
 
     @property
     def params_strategy(self) -> chex.ArrayTree:

--- a/evosax/strategies/differential_es.py
+++ b/evosax/strategies/differential_es.py
@@ -11,6 +11,7 @@ class Differential_ES(Strategy):
         Reference: https://tinyurl.com/4pje5a74"""
         assert popsize > 6
         super().__init__(num_dims, popsize)
+        self.strategy_name = "Differential_ES"
 
     @property
     def params_strategy(self) -> chex.ArrayTree:

--- a/evosax/strategies/open_es.py
+++ b/evosax/strategies/open_es.py
@@ -15,6 +15,7 @@ class Open_ES(Strategy):
         assert not self.popsize & 1, "Population size must be even"
         assert opt_name in ["sgd", "adam", "rmsprop", "clipup"]
         self.optimizer = GradientOptimizer[opt_name](self.num_dims)
+        self.strategy_name = "Open_ES"
 
     @property
     def params_strategy(self) -> chex.ArrayTree:

--- a/evosax/strategies/pbt_es.py
+++ b/evosax/strategies/pbt_es.py
@@ -10,6 +10,7 @@ class PBT_ES(Strategy):
         """Synchronous Population-Based Training (Jaderberg et al., 2017)
         Reference: https://arxiv.org/abs/1711.09846"""
         super().__init__(num_dims, popsize)
+        self.strategy_name = "PBT_ES"
 
     @property
     def params_strategy(self) -> chex.ArrayTree:

--- a/evosax/strategies/persistent_es.py
+++ b/evosax/strategies/persistent_es.py
@@ -16,6 +16,7 @@ class Persistent_ES(Strategy):
         assert not self.popsize & 1, "Population size must be even"
         assert opt_name in ["sgd", "adam", "rmsprop", "clipup"]
         self.optimizer = GradientOptimizer[opt_name](self.num_dims)
+        self.strategy_name = "Persistent_ES"
 
     @property
     def params_strategy(self) -> chex.ArrayTree:

--- a/evosax/strategies/pgpe_es.py
+++ b/evosax/strategies/pgpe_es.py
@@ -25,6 +25,7 @@ class PGPE_ES(Strategy):
         assert not self.popsize & 1, "Population size must be even"
         assert opt_name in ["sgd", "adam", "rmsprop", "clipup"]
         self.optimizer = GradientOptimizer[opt_name](self.num_dims)
+        self.strategy_name = "PGPE_ES"
 
     @property
     def params_strategy(self) -> chex.ArrayTree:

--- a/evosax/strategies/pso_es.py
+++ b/evosax/strategies/pso_es.py
@@ -10,6 +10,7 @@ class PSO_ES(Strategy):
         """Particle Swarm Optimization (Kennedy & Eberhart, 1995)
         Reference: https://ieeexplore.ieee.org/document/488968"""
         super().__init__(num_dims, popsize)
+        self.strategy_name = "PSO_ES"
 
     @property
     def params_strategy(self) -> chex.ArrayTree:

--- a/evosax/strategies/sep_cma_es.py
+++ b/evosax/strategies/sep_cma_es.py
@@ -1,0 +1,263 @@
+import jax
+import jax.numpy as jnp
+import chex
+from typing import Tuple
+from ..strategy import Strategy
+
+
+class Sep_CMA_ES(Strategy):
+    def __init__(self, num_dims: int, popsize: int, elite_ratio: float = 0.5):
+        """Separable CMA-ES (e.g. Ros & Hansen, 2008)
+        Reference: https://hal.inria.fr/inria-00287367/document
+        Inspired by: github.com/CyberAgentAILab/cmaes/blob/main/cmaes/_sepcma.py
+        """
+        super().__init__(num_dims, popsize)
+        assert 0 <= elite_ratio <= 1
+        self.elite_ratio = elite_ratio
+        self.elite_popsize = int(self.popsize * self.elite_ratio)
+        self.strategy_name = "Sep_CMA_ES"
+
+    @property
+    def params_strategy(self) -> chex.ArrayTree:
+        """Return default parameters of evolution strategy."""
+        weights_prime = jnp.array(
+            [
+                jnp.log(self.elite_popsize + 1) - jnp.log(i + 1)
+                for i in range(self.elite_popsize)
+            ]
+        )
+        weights = weights_prime / jnp.sum(weights_prime)
+        weights_truncated = jnp.zeros(self.popsize)
+        weights_truncated = weights_truncated.at[: self.elite_popsize].set(
+            weights
+        )
+        mu_eff = 1 / jnp.sum(weights ** 2)
+
+        # lrates for rank-one and rank-μ C updates
+        alpha_cov = 2
+        c_1 = alpha_cov / ((self.num_dims + 1.3) ** 2 + mu_eff)
+        c_mu_full = 2 / mu_eff / ((self.num_dims + jnp.sqrt(2)) ** 2) + (
+            1 - 1 / mu_eff
+        ) * jnp.minimum(
+            1, (2 * mu_eff - 1) / ((self.num_dims + 2) ** 2 + mu_eff)
+        )
+        c_mu = (self.num_dims + 2) / 3 * c_mu_full
+
+        # lrate for cumulation of step-size control and rank-one update
+        c_sigma = (mu_eff + 2) / (self.num_dims + mu_eff + 3)
+        d_sigma = (
+            1
+            + 2
+            * jnp.maximum(0, jnp.sqrt((mu_eff - 1) / (self.num_dims + 1)) - 1)
+            + c_sigma
+        )
+        c_c = 4 / (self.num_dims + 4)
+        chi_n = jnp.sqrt(self.num_dims) * (
+            1.0
+            - (1.0 / (4.0 * self.num_dims))
+            + 1.0 / (21.0 * (self.num_dims ** 2))
+        )
+
+        params = {
+            "mu_eff": mu_eff,
+            "c_1": c_1,
+            "c_mu": c_mu,
+            "c_m": 1.0,
+            "c_sigma": c_sigma,
+            "d_sigma": d_sigma,
+            "c_c": c_c,
+            "chi_n": chi_n,
+            "weights": weights,
+            "weights_truncated": weights_truncated,
+            "sigma_init": 1.0,
+            "init_min": 0.0,
+            "init_max": 0.0,
+        }
+        return params
+
+    def initialize_strategy(
+        self, rng: chex.PRNGKey, params: chex.ArrayTree
+    ) -> chex.ArrayTree:
+        """`initialize` the evolution strategy."""
+        # Initialize evolution paths & covariance matrix
+        initialization = jax.random.uniform(
+            rng,
+            (self.num_dims,),
+            minval=params["init_min"],
+            maxval=params["init_max"],
+        )
+        state = {
+            "p_sigma": jnp.zeros(self.num_dims),
+            "p_c": jnp.zeros(self.num_dims),
+            "sigma": params["sigma_init"],
+            "mean": initialization,
+            "C": jnp.ones(self.num_dims),
+            "D": None,
+        }
+        return state
+
+    def ask_strategy(
+        self, rng: chex.PRNGKey, state: chex.ArrayTree, params: chex.ArrayTree
+    ) -> Tuple[chex.Array, chex.ArrayTree]:
+        """`ask` for new parameter candidates to evaluate next."""
+        D = eigen_decomposition(state["C"], state["D"])
+        x = sample(
+            rng,
+            state["mean"],
+            state["sigma"],
+            D,
+            self.num_dims,
+            self.popsize,
+        )
+        state["D"] = D
+        return x, state
+
+    def tell_strategy(
+        self,
+        x: chex.Array,
+        fitness: chex.Array,
+        state: chex.ArrayTree,
+        params: chex.ArrayTree,
+    ) -> chex.ArrayTree:
+        """`tell` performance data for strategy state update."""
+        # Sort new results, extract elite, store best performer
+        concat_p_f = jnp.hstack([jnp.expand_dims(fitness, 1), x])
+        sorted_solutions = concat_p_f[concat_p_f[:, 0].argsort()]
+        # Update mean, isotropic/anisotropic paths, covariance, stepsize
+        y_k, y_w, mean = update_mean(
+            state["mean"], state["sigma"], sorted_solutions, params
+        )
+
+        p_sigma, D = update_p_sigma(
+            state["C"], state["D"], state["p_sigma"], y_w, params
+        )
+
+        p_c, norm_p_sigma, h_sigma = update_p_c(
+            mean, p_sigma, state["p_c"], state["gen_counter"] + 1, y_w, params
+        )
+
+        C = update_covariance(p_c, state["C"], y_k, h_sigma, params)
+        sigma = update_sigma(state["sigma"], norm_p_sigma, params)
+
+        state["mean"] = mean
+        state["p_sigma"] = p_sigma
+        state["C"] = C
+        state["D"] = D
+        state["p_c"] = p_c
+        state["C"] = C
+        state["sigma"] = sigma
+        return state
+
+
+def update_mean(
+    mean: chex.Array,
+    sigma: float,
+    sorted_solutions: chex.Array,
+    params: chex.ArrayTree,
+) -> Tuple[chex.Array, chex.Array, chex.Array]:
+    """Update mean of strategy."""
+    x_k = sorted_solutions[:, 1:]  # ~ N(m, σ^2 C)
+    y_k = (x_k - mean) / sigma  # ~ N(0, C)
+    y_w = jnp.sum(y_k.T * params["weights_truncated"], axis=1)
+    mean += params["c_m"] * sigma * y_w
+    return y_k, y_w, mean
+
+
+def update_p_sigma(
+    C: chex.Array,
+    D: chex.Array,
+    p_sigma: chex.Array,
+    y_w: chex.Array,
+    params: chex.ArrayTree,
+) -> Tuple[chex.Array, None]:
+    """Update evolution path for covariance matrix."""
+    D = eigen_decomposition(C, D)
+    p_sigma_new = (1 - params["c_sigma"]) * p_sigma + jnp.sqrt(
+        params["c_sigma"] * (2 - params["c_sigma"]) * params["mu_eff"]
+    ) * (y_w / D)
+    _D = None
+    return p_sigma_new, _D
+
+
+def update_p_c(
+    mean: chex.Array,
+    p_sigma: chex.Array,
+    p_c: chex.Array,
+    gen_counter: int,
+    y_w: chex.Array,
+    params: chex.ArrayTree,
+) -> Tuple[chex.Array, float, float]:
+    """Update evolution path for sigma/stepsize."""
+    norm_p_sigma = jnp.linalg.norm(p_sigma)
+    h_sigma_cond_left = norm_p_sigma / jnp.sqrt(
+        1 - (1 - params["c_sigma"]) ** (2 * (gen_counter))
+    )
+    h_sigma_cond_right = (1.4 + 2 / (mean.shape[0] + 1)) * params["chi_n"]
+    h_sigma = 1.0 * (h_sigma_cond_left < h_sigma_cond_right)
+    p_c_new = (1 - params["c_c"]) * p_c + h_sigma * jnp.sqrt(
+        params["c_c"] * (2 - params["c_c"]) * params["mu_eff"]
+    ) * y_w
+    return p_c_new, norm_p_sigma, h_sigma
+
+
+def update_covariance(
+    p_c: chex.Array,
+    C: chex.Array,
+    y_k: chex.Array,
+    h_sigma: float,
+    params: chex.ArrayTree,
+) -> chex.Array:
+    """Update cov. matrix estimator using rank 1 + μ updates."""
+    delta_h_sigma = (1 - h_sigma) * params["c_c"] * (2 - params["c_c"])
+    rank_one = p_c ** 2
+    rank_mu = jnp.sum(
+        jnp.array([w * (y ** 2) for w, y in zip(params["weights"], y_k)]),
+        axis=0,
+    )
+    C = (
+        (
+            1
+            + params["c_1"] * delta_h_sigma
+            - params["c_1"]
+            - params["c_mu"] * jnp.sum(params["weights"])
+        )
+        * C
+        + params["c_1"] * rank_one
+        + params["c_mu"] * rank_mu
+    )
+    return C
+
+
+def update_sigma(
+    sigma: float, norm_p_sigma: float, params: chex.ArrayTree
+) -> float:
+    """Update stepsize sigma."""
+    sigma_new = sigma * jnp.exp(
+        (params["c_sigma"] / params["d_sigma"])
+        * (norm_p_sigma / params["chi_n"] - 1)
+    )
+    return sigma_new
+
+
+def sample(
+    rng: chex.PRNGKey,
+    mean: chex.Array,
+    sigma: float,
+    D: chex.Array,
+    n_dim: int,
+    pop_size: int,
+) -> chex.Array:
+    """Jittable Gaussian Sample Helper."""
+    z = jax.random.normal(rng, (n_dim, pop_size))  # ~ N(0, I)
+    y = jnp.diag(D).dot(z)  # ~ N(0, C)
+    y = jnp.swapaxes(y, 1, 0)
+    x = mean + sigma * y  # ~ N(m, σ^2 C)
+    return x
+
+
+def eigen_decomposition(C: chex.Array, D: chex.Array) -> chex.Array:
+    """Perform simplified decomposition of covariance matrix."""
+    if D is not None:
+        return D
+    D = jnp.sqrt(jnp.where(C < 0, 1e-20, C))
+    return D

--- a/evosax/strategies/simple_es.py
+++ b/evosax/strategies/simple_es.py
@@ -13,6 +13,7 @@ class Simple_ES(Strategy):
         super().__init__(num_dims, popsize)
         self.elite_ratio = elite_ratio
         self.elite_popsize = int(self.popsize * self.elite_ratio)
+        self.strategy_name = "Simple_ES"
 
     @property
     def params_strategy(self) -> chex.ArrayTree:
@@ -26,7 +27,7 @@ class Simple_ES(Strategy):
             "c_m": 1.0,  # Learning rate for population mean
             "c_sigma": 0.1,  # Learning rate for population std
             "weights": weights,  # Weights for population members
-            "sigma_init": 1,  # Standard deviation
+            "sigma_init": 1.0,  # Standard deviation
             "init_min": 0.0,
             "init_max": 0.0,
         }
@@ -42,8 +43,6 @@ class Simple_ES(Strategy):
             maxval=params["init_max"],
         )
         state = {
-            "archive": initialization,
-            "fitness": jnp.zeros(self.elite_popsize) - 20e10,
             "mean": jnp.zeros(self.num_dims),
             "sigma": jnp.repeat(params["sigma_init"], self.num_dims),
         }

--- a/evosax/strategies/simple_ga.py
+++ b/evosax/strategies/simple_ga.py
@@ -14,6 +14,7 @@ class Simple_GA(Strategy):
         super().__init__(num_dims, popsize)
         self.elite_ratio = elite_ratio
         self.elite_popsize = int(self.popsize * self.elite_ratio)
+        self.strategy_name = "Simple_GA"
 
     @property
     def params_strategy(self) -> chex.ArrayTree:

--- a/evosax/strategies/xnes.py
+++ b/evosax/strategies/xnes.py
@@ -11,6 +11,7 @@ class xNES(Strategy):
         Reference: https://www.jmlr.org/papers/volume15/wierstra14a/wierstra14a.pdf
         Inspired by: https://github.com/chanshing/xnes"""
         super().__init__(num_dims, popsize)
+        self.strategy_name = "xNES"
 
     @property
     def params_strategy(self) -> chex.ArrayTree:

--- a/evosax/utils/reshape_params.py
+++ b/evosax/utils/reshape_params.py
@@ -53,9 +53,9 @@ class ParameterReshaper(object):
             self.n_devices = n_devices
         if self.n_devices > 1:
             print(
-                "More than one device detected. Please make sure that the ES"
-                " population size divides evenly across the number of devices"
-                " to pmap/parallelize over."
+                "ParameterReshaper: More than one device detected. Please make"
+                " sure that the ES population size divides evenly across the"
+                " number of devices to pmap/parallelize over."
             )
 
     def reshape_identity(self, x: chex.Array) -> chex.Array:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,7 @@ def pytest_generate_tests(metafunc):
                     "PBT_ES",
                     "Persistent_ES",
                     "xNES",
+                    "Sep_CMA_ES",
                 ],
             )
         else:

--- a/tests/test_strategy_restarts.py
+++ b/tests/test_strategy_restarts.py
@@ -1,7 +1,7 @@
 import jax
 import jax.numpy as jnp
 from evosax import CMA_ES
-from evosax.restarts import Simple_Restarter
+from evosax.restarts import Simple_Restarter, BIPOP_Restarter
 
 
 def test_simple_restart():
@@ -23,3 +23,43 @@ def test_simple_restart():
     state = re_strategy.tell(rng, x, fitness, state, re_es_params)
     assert state["restarted"] == True
     assert (state["mean"] == jnp.zeros(2)).all()
+
+
+def test_bipop_restart():
+    rng = jax.random.PRNGKey(0)
+    strategy = CMA_ES(popsize=4, num_dims=2)
+    re_strategy = BIPOP_Restarter(strategy)
+    re_es_params = re_strategy.default_params
+    re_es_params["min_num_gens"] = 2
+    state = re_strategy.initialize(rng, re_es_params)
+    # Run 1st ask-tell-generation
+    x, state = re_strategy.ask(rng, state, re_es_params)
+    fitness = jnp.array([1.0, 2.0, 3.0, 4.0])
+    state = re_strategy.tell(rng, x, fitness, state, re_es_params)
+    assert state["restarted"] == False
+    assert state["active_popsize"] == 4
+
+    # Run 2nd ask-tell-generation
+    x, state = re_strategy.ask(rng, state, re_es_params)
+    fitness = jnp.array([0.0, 0.0, 0.0, 0.0])
+    state = re_strategy.tell(rng, x, fitness, state, re_es_params)
+    assert state["restarted"] == True
+    assert (state["mean"] == jnp.zeros(2)).all()
+    assert state["active_popsize"] == 8
+
+    # Run 3rd ask-tell-generation
+    x, state = re_strategy.ask(rng, state, re_es_params)
+    fitness = jnp.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0])
+    re_es_params = re_strategy.default_params
+    re_es_params["min_num_gens"] = 2
+    state = re_strategy.tell(rng, x, fitness, state, re_es_params)
+    assert state["restarted"] == False
+    assert state["active_popsize"] == 8
+
+    # Run 4th ask-tell-generation
+    x, state = re_strategy.ask(rng, state, re_es_params)
+    fitness = jnp.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+    state = re_strategy.tell(rng, x, fitness, state, re_es_params)
+    assert state["restarted"] == True
+    assert (state["mean"] == jnp.zeros(2)).all()
+    assert state["active_popsize"] <= 8

--- a/tests/test_strategy_restarts.py
+++ b/tests/test_strategy_restarts.py
@@ -1,0 +1,25 @@
+import jax
+import jax.numpy as jnp
+from evosax import CMA_ES
+from evosax.restarts import Simple_Restarter
+
+
+def test_simple_restart():
+    rng = jax.random.PRNGKey(0)
+    strategy = CMA_ES(popsize=4, num_dims=2)
+    re_strategy = Simple_Restarter(strategy)
+    re_es_params = re_strategy.default_params
+    re_es_params["min_num_gens"] = 2
+    state = re_strategy.initialize(rng, re_es_params)
+    # Run 1st ask-tell-generation
+    x, state = re_strategy.ask(rng, state, re_es_params)
+    fitness = jnp.array([1.0, 2.0, 3.0, 4.0])
+    state = re_strategy.tell(rng, x, fitness, state, re_es_params)
+    assert state["restarted"] == False
+
+    # Run 2nd ask-tell-generation
+    x, state = re_strategy.ask(rng, state, re_es_params)
+    fitness = jnp.array([0.0, 0.0, 0.0, 0.0])
+    state = re_strategy.tell(rng, x, fitness, state, re_es_params)
+    assert state["restarted"] == True
+    assert (state["mean"] == jnp.zeros(2)).all()

--- a/tests/test_strategy_run.py
+++ b/tests/test_strategy_run.py
@@ -14,12 +14,8 @@ def test_strategy_run(strategy_name):
     Strat = Strategies[strategy_name]
     # PBT also returns copy ID integer - treat separately
     popsize = 20
-    if strategy_name in ["Open_ES", "PGPE_ES", "Augmented_RS"]:
-        evaluator = ClassicFitness("quadratic", 2)
-        fitness_shaper = FitnessShaper(z_score=True)
-    else:
-        evaluator = ClassicFitness("rosenbrock", 2)
-        fitness_shaper = FitnessShaper()
+    evaluator = ClassicFitness("rosenbrock", 2)
+    fitness_shaper = FitnessShaper()
 
     batch_eval = evaluator.rollout
     strategy = Strat(popsize=popsize, num_dims=2)
@@ -44,13 +40,8 @@ def test_strategy_scan(strategy_name):
     Strat = Strategies[strategy_name]
     # PBT also returns copy ID integer - treat separately
     popsize = 20
-
-    if strategy_name in ["Open_ES", "PGPE_ES", "Augmented_RS"]:
-        evaluator = ClassicFitness("quadratic", 2)
-        fitness_shaper = FitnessShaper(z_score=True)
-    else:
-        evaluator = ClassicFitness("rosenbrock", 2)
-        fitness_shaper = FitnessShaper()
+    evaluator = ClassicFitness("rosenbrock", 2)
+    fitness_shaper = FitnessShaper()
 
     batch_eval = evaluator.rollout
     strategy = Strat(popsize=popsize, num_dims=2)


### PR DESCRIPTION
- Adds a base Restart Wrapper, a simple reinit and a non-jittable BIPOP (interlaced small/large population size) wrapper for restarting.
- Adds a Separable CMA-ES strategy (tested on Rosenbrock and CartPole-MLP), which works with a diagonal covariance matrix. This circumvents an expensive eigendecomposition at the cost of ignoring dimension dependencies.