### PR TITLE
fix top_k log

### DIFF
--- a/evosax/utils/es_logger.py
+++ b/evosax/utils/es_logger.py
@@ -57,7 +57,7 @@ class ESLog(object):
         params = jnp.vstack([log["top_params"], x])
         top_idx = (
             self.maximize * ((-1) * vals).argsort()
-            + ((1 - self.maximize) * vals).argsort()
+            + ((1 - self.maximize) * vals.argsort())
         )
         log["top_fitness"] = vals[top_idx[: self.top_k]]
         log["top_params"] = params[top_idx[: self.top_k]]

--- a/tests/test_es_log.py
+++ b/tests/test_es_log.py
@@ -11,3 +11,14 @@ def test_es_log():
     assert log["log_top_1"][0] == 4
     assert log["top_params"][0][0] == 6
     assert log["top_params"][0][1] == 7
+
+def test_top_k():
+    es_logging = ESLog(num_dims=2, num_generations=10, top_k=3, maximize=True)
+    log = es_logging.initialize()
+    x = jnp.array([[1, 2], [2, 4], [4, 6], [6, 7]])
+    fitness = jnp.array([1, 2, 3, 4])
+    log = es_logging.update(log, x, fitness)
+    assert jnp.array_equal(log["top_fitness"], jnp.array([4, 3, 2]))
+    assert jnp.array_equal(log["top_params"][0], jnp.array([6, 7]))
+    assert jnp.array_equal(log["top_params"][1], jnp.array([4, 6]))
+    assert jnp.array_equal(log["top_params"][2], jnp.array([2, 4]))


### PR DESCRIPTION
Calculation of the top `k` agents using `ESLog` is incorrect. 

Expectation: 
``` 
    es_logging = ESLog(num_dims=2, num_generations=10, top_k=3, maximize=True)
    log = es_logging.initialize()
    x = jnp.array([[1, 2], [2, 4], [4, 6], [6, 7]])
    fitness = jnp.array([1, 2, 3, 4])
    assert jnp.array_equal(log["top_fitness"], jnp.array([4, 3, 2]))
    # Pass: [4. 3. 2.] 
```

Reality: 
``` 
    es_logging = ESLog(num_dims=2, num_generations=10, top_k=3, maximize=True)
    log = es_logging.initialize()
    x = jnp.array([[1, 2], [2, 4], [4, 6], [6, 7]])
    fitness = jnp.array([1, 2, 3, 4])
    assert jnp.array_equal(log["top_fitness"], jnp.array([4, 3, 2]))
    # AssertionError: [4. 4. 4.]
```

Fix for Issue #24 

`L:58` of `es_logger.py`: the second `argsort()` in `top_idx` is one parenthesis off. 