### PR TITLE
ParameterReshaper should support any PyTrees not only dicts

### DIFF
--- a/evosax/utils/reshape_params.py
+++ b/evosax/utils/reshape_params.py
@@ -4,6 +4,7 @@ import chex
 from typing import Union, List, Optional
 from flax.core.frozen_dict import FrozenDict, unfreeze
 from flax.traverse_util import flatten_dict, unflatten_dict
+from jax.tree_util import tree_flatten, tree_unflatten
 
 
 class ParameterReshaper(object):
@@ -12,35 +13,17 @@ class ParameterReshaper(object):
         placeholder_params: Union[chex.ArrayTree, chex.Array],
         identity: bool = False,
         n_devices: Optional[int] = None,
-        separator: str = '$',
         verbose: bool = True,
     ):
         """Reshape flat parameters vectors into generation eval shape."""
-        self._separator = separator
         # Get network shape to reshape
         self.placeholder_params = placeholder_params
-        if type(placeholder_params) == dict:
-            flat_params = {
-                self._separator.join(k): v
-                for k, v in flatten_dict(self.placeholder_params).items()
-            }
-            self.unflat_shape = jax.tree_map(jnp.shape, self.placeholder_params)
-            self.network_shape = jax.tree_map(jnp.shape, flat_params)
-            self.total_params = get_total_params(self.network_shape)
-            self.l_id = get_layer_ids(self.network_shape)
-        elif type(placeholder_params) == FrozenDict:
-            self.placeholder_params = unfreeze(self.placeholder_params)
-            flat_params = {
-                self._separator.join(k): v
-                for k, v in flatten_dict(self.placeholder_params).items()
-            }
-            self.unflat_shape = jax.tree_map(jnp.shape, self.placeholder_params)
-            self.network_shape = jax.tree_map(jnp.shape, flat_params)
-            self.total_params = get_total_params(self.network_shape)
-            self.l_id = get_layer_ids(self.network_shape)
-        else:
-            # Classic problem case - no dict but raw array
-            self.total_params = self.placeholder_params.shape[0]
+
+        leafs, treedef = jax.tree_util.tree_flatten(placeholder_params)
+        self._treedef = treedef
+        self.network_shape = jax.tree_map(jnp.shape, leafs)
+        self.total_params = get_total_params(self.network_shape)
+        self.l_id = get_layer_ids(self.network_shape)
 
         # Special case for no identity mapping (no pytree reshaping)
         if identity:
@@ -98,43 +81,39 @@ class ParameterReshaper(object):
 
     def flat_to_network(self, flat_params: chex.Array) -> chex.ArrayTree:
         """Fill a FrozenDict with new proposed vector of params."""
-        new_nn = {}
-        layer_keys = self.network_shape.keys()
+        new_nn = list()
 
         # Loop over layers in network
-        for i, p_k in enumerate(layer_keys):
+        for i, shape in enumerate(self.network_shape):
             # Select params from flat to vector to be reshaped
             p_flat = jax.lax.dynamic_slice(
                 flat_params, (self.l_id[i],), (self.l_id[i + 1] - self.l_id[i],)
             )
             # Reshape parameters into matrix/kernel/etc. shape
-            p_reshaped = p_flat.reshape(self.network_shape[p_k])
+            p_reshaped = p_flat.reshape(shape)
             # Place reshaped params into dict and increase counter
-            new_nn[p_k] = p_reshaped
-        return unflatten_dict(
-            {tuple(k.split(self._separator)): v for k, v in new_nn.items()}
-        )
+            new_nn.append(p_reshaped)
+        return tree_unflatten(self._treedef, new_nn)
 
     def split_params_for_pmap(self, param: chex.Array) -> chex.Array:
         """Helper reshapes param (bs, #params) into (#dev, bs/#dev, #params)."""
         return jnp.stack(jnp.split(param, self.n_devices))
 
 
-def get_total_params(params: chex.ArrayTree) -> int:
+def get_total_params(params: List[chex.Array]) -> int:
     """Get total number of params in net. Loop over layer modules + params."""
     total_params = 0
-    layer_keys = list(params.keys())
+    layer_keys = params
     # Loop over layers
     for l_k in layer_keys:
-        total_params += jnp.prod(jnp.array(params[l_k]))
+        total_params += jnp.prod(jnp.array(l_k))
     return total_params
 
 
-def get_layer_ids(network_shape: chex.ArrayTree) -> List[int]:
+def get_layer_ids(network_shape_list: List[chex.Array]) -> List[int]:
     """Get indices to target when reshaping single flat net into dict."""
-    layer_keys = list(network_shape.keys())
     l_id = [0]
-    for l in layer_keys:
-        add_pcount = jnp.prod(jnp.array(network_shape[l]))
+    for shape in network_shape_list:
+        add_pcount = jnp.prod(jnp.array(shape))
         l_id.append(int(l_id[-1] + add_pcount))
     return l_id


### PR DESCRIPTION
See issue: https://github.com/RobertTLange/evosax/issues/25

The current version of the ParameterReshaper only supports Dicts for reshaping. This is fine for libraries like Flax and Haiku, but e.g. [Equinox](https://github.com/patrick-kidger/equinox) uses a DataClass internally which is not supported here.
A simple solution would be to utilize the tree_unflatten and tree_flatten functions that are provided by jax.tree_utils. This would also enable support for lists, tuples, and any kind of PyTrees as long as they are registered with jax.