### PR TITLE
Ensure elite population is at least 1 where applicable

### DIFF
--- a/evosax/strategies/ars.py
+++ b/evosax/strategies/ars.py
@@ -45,7 +45,7 @@ class ARS(Strategy):
         # "b" elite perturbation directions for the update
         assert 0 <= elite_ratio <= 1
         self.elite_ratio = elite_ratio
-        self.elite_popsize = int(self.popsize / 2 * self.elite_ratio)
+        self.elite_popsize = max(1, int(self.popsize / 2 * self.elite_ratio))
         assert opt_name in ["sgd", "adam", "rmsprop", "clipup"]
         self.optimizer = GradientOptimizer[opt_name](self.num_dims)
         self.strategy_name = "ARS"

--- a/evosax/strategies/cma_es.py
+++ b/evosax/strategies/cma_es.py
@@ -87,7 +87,7 @@ class CMA_ES(Strategy):
         super().__init__(num_dims, popsize)
         assert 0 <= elite_ratio <= 1
         self.elite_ratio = elite_ratio
-        self.elite_popsize = int(self.popsize * self.elite_ratio)
+        self.elite_popsize = max(1, int(self.popsize * self.elite_ratio))
         self.strategy_name = "CMA_ES"
 
     @property

--- a/evosax/strategies/full_iamalgam.py
+++ b/evosax/strategies/full_iamalgam.py
@@ -46,7 +46,7 @@ class Full_iAMaLGaM(Strategy):
         super().__init__(num_dims, popsize)
         assert 0 <= elite_ratio <= 1
         self.elite_ratio = elite_ratio
-        self.elite_popsize = int(self.popsize * self.elite_ratio)
+        self.elite_popsize = max(1, int(self.popsize * self.elite_ratio))
         alpha_ams = (
             0.5
             * self.elite_ratio

--- a/evosax/strategies/indep_iamalgam.py
+++ b/evosax/strategies/indep_iamalgam.py
@@ -51,7 +51,7 @@ class Indep_iAMaLGaM(Strategy):
         super().__init__(num_dims, popsize)
         assert 0 <= elite_ratio <= 1
         self.elite_ratio = elite_ratio
-        self.elite_popsize = int(self.popsize * self.elite_ratio)
+        self.elite_popsize = max(1, int(self.popsize * self.elite_ratio))
         alpha_ams = (
             0.5
             * self.elite_ratio

--- a/evosax/strategies/lm_ma_es.py
+++ b/evosax/strategies/lm_ma_es.py
@@ -52,7 +52,7 @@ class LM_MA_ES(Strategy):
         super().__init__(num_dims, popsize)
         assert 0 <= elite_ratio <= 1
         self.elite_ratio = elite_ratio
-        self.elite_popsize = int(self.popsize * self.elite_ratio)
+        self.elite_popsize = max(1, int(self.popsize * self.elite_ratio))
         self.memory_size = memory_size
         self.strategy_name = "LM_MA_ES"
 

--- a/evosax/strategies/ma_es.py
+++ b/evosax/strategies/ma_es.py
@@ -43,7 +43,7 @@ class MA_ES(Strategy):
         super().__init__(num_dims, popsize)
         assert 0 <= elite_ratio <= 1
         self.elite_ratio = elite_ratio
-        self.elite_popsize = int(self.popsize * self.elite_ratio)
+        self.elite_popsize = max(1, int(self.popsize * self.elite_ratio))
         self.strategy_name = "MA_ES"
 
     @property

--- a/evosax/strategies/pgpe.py
+++ b/evosax/strategies/pgpe.py
@@ -45,7 +45,7 @@ class PGPE(Strategy):
         super().__init__(num_dims, popsize)
         assert 0 <= elite_ratio <= 1
         self.elite_ratio = elite_ratio
-        self.elite_popsize = int(self.popsize / 2 * self.elite_ratio)
+        self.elite_popsize = max(1, int(self.popsize / 2 * self.elite_ratio))
 
         assert not self.popsize & 1, "Population size must be even"
         assert opt_name in ["sgd", "adam", "rmsprop", "clipup"]

--- a/evosax/strategies/rm_es.py
+++ b/evosax/strategies/rm_es.py
@@ -73,7 +73,7 @@ class RmES(Strategy):
         super().__init__(num_dims, popsize)
         assert 0 <= elite_ratio <= 1
         self.elite_ratio = elite_ratio
-        self.elite_popsize = int(self.popsize * self.elite_ratio)
+        self.elite_popsize = max(1, int(self.popsize * self.elite_ratio))
         self.memory_size = memory_size  # number of ranks
         self.strategy_name = "RmES"
 

--- a/evosax/strategies/sep_cma_es.py
+++ b/evosax/strategies/sep_cma_es.py
@@ -65,7 +65,7 @@ class Sep_CMA_ES(Strategy):
         super().__init__(num_dims, popsize)
         assert 0 <= elite_ratio <= 1
         self.elite_ratio = elite_ratio
-        self.elite_popsize = int(self.popsize * self.elite_ratio)
+        self.elite_popsize = max(1, int(self.popsize * self.elite_ratio))
         self.strategy_name = "Sep_CMA_ES"
 
     @property

--- a/evosax/strategies/simple_es.py
+++ b/evosax/strategies/simple_es.py
@@ -34,7 +34,7 @@ class SimpleES(Strategy):
         Inspired by: https://github.com/hardmaru/estool/blob/master/es.py"""
         super().__init__(num_dims, popsize)
         self.elite_ratio = elite_ratio
-        self.elite_popsize = int(self.popsize * self.elite_ratio)
+        self.elite_popsize = max(1, int(self.popsize * self.elite_ratio))
         self.strategy_name = "SimpleES"
 
     @property

--- a/evosax/strategies/simple_ga.py
+++ b/evosax/strategies/simple_ga.py
@@ -37,7 +37,7 @@ class SimpleGA(Strategy):
 
         super().__init__(num_dims, popsize)
         self.elite_ratio = elite_ratio
-        self.elite_popsize = int(self.popsize * self.elite_ratio)
+        self.elite_popsize = max(1, int(self.popsize * self.elite_ratio))
         self.strategy_name = "SimpleGA"
 
     @property


### PR DESCRIPTION
Per Issue #29 the `__init__` of the following strategies have been updated to ensure the elite population size is >= 1:

- PGPE
- ARS
- CMA_ES
- Sep_CMA_ES
- SimpleES
- SimpleGA
- Full_iAMaLGaM/Indep_iAMaLGaM
- MA_ES
- LM_MA_ES
- RM_ES

Ex: 
`self.elite_popsize = int(self.popsize * self.elite_ratio)`
becomes:
`self.elite_popsize = max(1, int(self.popsize * self.elite_ratio))`