### PR TITLE
Avoid ZeroDivisionError in PGPE

### DIFF
--- a/evosax/strategies/pgpe.py
+++ b/evosax/strategies/pgpe.py
@@ -107,7 +107,7 @@ class PGPE(Strategy):
         fit_diff = fit_1[elite_idx] - fit_2[elite_idx]
         fit_diff_noise = jnp.dot(noise_1[elite_idx].T, fit_diff)
 
-        theta_grad = 1.0 / self.elite_popsize * fit_diff_noise
+        theta_grad = 1.0 / (self.elite_popsize * fit_diff_noise + jnp.finfo(jnp.float32).eps)
         # Grad update using optimizer instance - decay lrate if desired
         mean, opt_state = self.optimizer.step(
             state.mean, theta_grad, state.opt_state, params.opt_params


### PR DESCRIPTION
I am seeing many `ZeroDivisionError: float division by zero` errors when using PGPE. The offending line is the following
```
theta_grad = 1.0 / self.elite_popsize * fit_diff_noise
```
Unless there is more principled way to do it, I would suggest to make the division numerically save as in this proposed commit.