### PR TITLE
Replace jax.lax.select with jax.numpy.where.

### DIFF
--- a/evosax/core/optimizer.py
+++ b/evosax/core/optimizer.py
@@ -245,7 +245,7 @@ class ClipUp(Optimizer):
             vel_magnitude = jnp.sqrt(jnp.sum(velocity * velocity))
             ratio_scale = vel_magnitude > max_speed
             scaled_vel = velocity * (max_speed / (vel_magnitude + 1e-08))
-            x_out = jax.lax.select(ratio_scale, scaled_vel, velocity)
+            x_out = jax.numpy.where(ratio_scale, scaled_vel, velocity)
             return x_out
 
         # Clip the update velocity and apply the update

--- a/evosax/learned_eo/les_tools.py
+++ b/evosax/learned_eo/les_tools.py
@@ -86,7 +86,7 @@ class FitnessFeatures(object):
         self, x: chex.Array, fitness: chex.Array, best_fitness: float
     ) -> chex.Array:
         """Compute and concatenate different fitness transformations."""
-        fitness = jax.lax.select(self.maximize, -1 * fitness, fitness)
+        fitness = jax.numpy.where(self.maximize, -1 * fitness, fitness)
         fit_out = ((fitness < best_fitness) * 1.0).reshape(-1, 1)
 
         if self.centered_rank:

--- a/evosax/problems/bbob.py
+++ b/evosax/problems/bbob.py
@@ -81,7 +81,7 @@ def EllipsoidalOriginal(
     z_vec = jax.vmap(oscillation_trafo)(arr)
 
     def get_val(i):
-        exp = jax.lax.select(dim > 1, 6.0 * i / (dim - 1), 6.0)
+        exp = jax.numpy.where(dim > 1, 6.0 * i / (dim - 1), 6.0)
         s = 10 ** exp * z_vec[i] * z_vec[i]
         return s
 
@@ -112,11 +112,11 @@ def BuecheRastrigin(
         max_dims: int, vector: chex.Array, num_dims: int
     ) -> chex.Array:
         def get_val(i):
-            s = jax.lax.select(
+            s = jax.numpy.where(
                 num_dims > 1, 10 ** (0.5 * (i / (num_dims - 1.0))), 10 ** 0.5
             )
             extra_cond = jnp.logical_and(i % 2 == 0, vector[i] > 0)
-            s = jax.lax.select(extra_cond, s * 10, s)
+            s = jax.numpy.where(extra_cond, s * 10, s)
             return s
 
         return jax.vmap(get_val, in_axes=0)(jnp.arange(max_dims))
@@ -136,7 +136,7 @@ def LinearSlope(arr: chex.Array, R: chex.Array, Q: chex.Array) -> chex.Array:
     z = jnp.matmul(R, arr)
 
     def get_val(i):
-        s = 10 ** jax.lax.select(dim > 1, i / (dim - 1.0), 1.0)
+        s = 10 ** jax.numpy.where(dim > 1, i / (dim - 1.0), 1.0)
         z_opt = 5 * jnp.sum(jnp.abs(R[i, :]))
         return s * (z_opt - z[i])
 
@@ -156,7 +156,7 @@ def AttractiveSector(
 
     def get_val(i):
         z = z_vec[i]
-        s = jax.lax.select(z * x_opt[i] > 0, 100, 1)
+        s = jax.numpy.where(z * x_opt[i] > 0, 100, 1)
         return (s * z) ** 2
 
     out = jax.vmap(get_val)(jnp.arange(dim))
@@ -181,7 +181,7 @@ def StepEllipsoidal(
     z_tilde = jnp.matmul(Q, z_tilde)
 
     def get_val(i):
-        exponent = jax.lax.select(dim > 1.0, 2.0 * i / (dim - 1.0), 2.0)
+        exponent = jax.numpy.where(dim > 1.0, 2.0 * i / (dim - 1.0), 2.0)
         return 10.0 ** exponent * z_tilde[i] ** 2
 
     out = jax.vmap(get_val)(jnp.arange(dim))
@@ -231,7 +231,7 @@ def EllipsoidalRotated(
     z_vec = jax.vmap(oscillation_trafo)(r_x)
 
     def get_val(i):
-        exp = jax.lax.select(dim > 1, 6.0 * i / (dim - 1), 6.0)
+        exp = jax.numpy.where(dim > 1, 6.0 * i / (dim - 1), 6.0)
         s = 10 ** exp * z_vec[i] * z_vec[i]
         return s
 

--- a/evosax/problems/bbob_helpers.py
+++ b/evosax/problems/bbob_helpers.py
@@ -27,9 +27,9 @@ def lambda_alpha_trafo(alpha: float, num_dims: int) -> chex.Array:
 def oscillation_trafo(element: float) -> chex.Array:
     """Oscillation trafo function for x array input & f value output.
     (p.3; Hansen et al., 2009)"""
-    x_carat = jax.lax.select(element == 0, 0.0, jnp.log(jnp.abs(element)))
-    c1 = jax.lax.select(element > 0, 10.0, 5.5)
-    c2 = jax.lax.select(element > 0, 7.9, 3.1)
+    x_carat = jax.numpy.where(element == 0, 0.0, jnp.log(jnp.abs(element)))
+    c1 = jax.numpy.where(element > 0, 10.0, 5.5)
+    c2 = jax.numpy.where(element > 0, 7.9, 3.1)
     return jnp.sign(element) * jnp.exp(
         x_carat + 0.049 * (jnp.sin(c1 * x_carat) + jnp.sin(c2 * x_carat))
     )
@@ -43,9 +43,9 @@ def asymmetry_trafo(
     dim = vector.shape[0]
 
     def get_asy_val(idx, val):
-        t = jax.lax.select(num_dims > 1, idx / (num_dims - 1.0), 1.0)
+        t = jax.numpy.where(num_dims > 1, idx / (num_dims - 1.0), 1.0)
         exp_l0 = 1 + beta * t * (val ** 0.5)
-        exp = jax.lax.select(val > 0, exp_l0, 1.0)
+        exp = jax.numpy.where(val > 0, exp_l0, 1.0)
         return val ** exp
 
     return jax.vmap(get_asy_val, in_axes=(0, 0))(jnp.arange(dim), vector)

--- a/evosax/restarts/bipop_restart.py
+++ b/evosax/restarts/bipop_restart.py
@@ -101,14 +101,14 @@ class BIPOP_Restarter(RestartWrapper):
     ) -> chex.ArrayTree:
         """Reinstantiate a new strategy with interlaced population sizes."""
         # Track number of evals depending on active population
-        large_eval_budget = jax.lax.select(
+        large_eval_budget = jax.numpy.where(
             state.restart_state.small_pop_active,
             state.restart_state.large_eval_budget,
             state.restart_state.large_eval_budget
             + state.restart_state.active_popsize
             * state.strategy_state.gen_counter,
         )
-        small_eval_budget = jax.lax.select(
+        small_eval_budget = jax.numpy.where(
             state.restart_state.small_pop_active,
             state.restart_state.small_eval_budget
             + state.restart_state.active_popsize
@@ -127,7 +127,7 @@ class BIPOP_Restarter(RestartWrapper):
         large_popsize = self.default_popsize * pop_mult
 
         # Reinstantiate new strategy - based on name of previous strategy
-        active_popsize = jax.lax.select(
+        active_popsize = jax.numpy.where(
             small_pop_active, small_popsize, large_popsize
         )
 
@@ -142,7 +142,7 @@ class BIPOP_Restarter(RestartWrapper):
             rng, params.strategy_params
         )
         strategy_state = strategy_state.replace(
-            mean=jax.lax.select(
+            mean=jax.numpy.where(
                 params.restart_params.copy_mean,
                 state.strategy_state.mean,
                 strategy_state.mean,

--- a/evosax/restarts/ipop_restart.py
+++ b/evosax/restarts/ipop_restart.py
@@ -110,7 +110,7 @@ class IPOP_Restarter(RestartWrapper):
             rng, params.strategy_params
         )
         strategy_state = strategy_state.replace(
-            mean=jax.lax.select(
+            mean=jax.numpy.where(
                 params.restart_params.copy_mean,
                 state.strategy_state.mean,
                 strategy_state.mean,

--- a/evosax/restarts/restarter.py
+++ b/evosax/restarts/restarter.py
@@ -91,7 +91,7 @@ class RestartWrapper(object):
         # Simple tree map - jittable if state dimensions are static
         # Otherwise restart wrapper has to overwrite `ask`
         new_state = jax.tree_map(
-            lambda x, y: jax.lax.select(state.restart_state.restart_next, x, y),
+            lambda x, y: jax.numpy.where(state.restart_state.restart_next, x, y),
             restart_state,
             state,
         )

--- a/evosax/restarts/simple_restart.py
+++ b/evosax/restarts/simple_restart.py
@@ -35,7 +35,7 @@ class Simple_Restarter(RestartWrapper):
         """Simple restart by state initialization."""
         new_state = self.base_strategy.initialize(rng, params.strategy_params)
         new_state = new_state.replace(
-            mean=jax.lax.select(
+            mean=jax.numpy.where(
                 params.restart_params.copy_mean,
                 state.strategy_state.mean,
                 new_state.mean,

--- a/evosax/strategies/asebo.py
+++ b/evosax/strategies/asebo.py
@@ -151,7 +151,7 @@ class ASEBO(Strategy):
 
         subspace_ready = state.gen_counter > self.subspace_dims
 
-        UUT = jax.lax.select(
+        UUT = jax.numpy.where(
             subspace_ready, UUT, jnp.zeros((self.num_dims, self.num_dims))
         )
         cov = (
@@ -186,7 +186,7 @@ class ASEBO(Strategy):
             jnp.dot(theta_grad, state.UUT_ort)
         ) / jnp.linalg.norm(jnp.dot(theta_grad, state.UUT))
         subspace_ready = state.gen_counter > self.subspace_dims
-        alpha = jax.lax.select(subspace_ready, alpha, 1.0)
+        alpha = jax.numpy.where(subspace_ready, alpha, 1.0)
 
         # Add grad FIFO-style to subspace archive (only if provided else FD)
         grad_subspace = jnp.zeros((self.subspace_dims, self.num_dims))

--- a/evosax/strategies/cr_fm_nes.py
+++ b/evosax/strategies/cr_fm_nes.py
@@ -228,11 +228,11 @@ class CR_FM_NES(Strategy):
 
         # switching weights and learning rate
         p_sigma_cond = p_sigma_norm >= params.chi_N
-        weights = jax.lax.select(p_sigma_cond, weights_dist, state.w_rank)
-        lrate_sigma = jax.lax.select(
+        weights = jax.numpy.where(p_sigma_cond, weights_dist, state.w_rank)
+        lrate_sigma = jax.numpy.where(
             p_sigma_cond, params.lrate_move_sigma, params.lrate_stag_sigma
         )
-        lrate_sigma = jax.lax.select(
+        lrate_sigma = jax.numpy.where(
             p_sigma_norm >= 0.1 * params.chi_N,
             lrate_sigma,
             params.lrate_conv_sigma,

--- a/evosax/strategies/de.py
+++ b/evosax/strategies/de.py
@@ -147,24 +147,24 @@ def single_member_ask(
     row_ids = jax.random.choice(
         rng_vectors, jnp.arange(archive.shape[0]), (6,), replace=False
     )
-    a = jax.lax.select(
+    a = jax.numpy.where(
         row_ids[0] == member_id, archive[row_ids[5]], archive[row_ids[0]]
     )
-    b = jax.lax.select(
+    b = jax.numpy.where(
         row_ids[1] == member_id, archive[row_ids[5]], archive[row_ids[1]]
     )
-    c = jax.lax.select(
+    c = jax.numpy.where(
         row_ids[2] == member_id, archive[row_ids[5]], archive[row_ids[2]]
     )
-    d = jax.lax.select(
+    d = jax.numpy.where(
         row_ids[3] == member_id, archive[row_ids[5]], archive[row_ids[3]]
     )
-    e = jax.lax.select(
+    e = jax.numpy.where(
         row_ids[4] == member_id, archive[row_ids[5]], archive[row_ids[4]]
     )
 
     # Use best vector instead of random `a` vector if `mutate_vector` == "best"
-    a = jax.lax.select(params.mutate_best_vector, best_member, a)
+    a = jax.numpy.where(params.mutate_best_vector, best_member, a)
 
     # Sample random dimension that will be alter for sure
     R = jax.random.randint(rng_R, (1,), minval=0, maxval=num_dims)

--- a/evosax/strategies/full_iamalgam.py
+++ b/evosax/strategies/full_iamalgam.py
@@ -255,30 +255,30 @@ def adaptive_variance_scaling(
 ) -> Tuple[float, int]:
     """AVS - adaptively rescale covariance depending on SDR."""
     # Case 1: If improvement in best fitness -> SDR increase c_mult! [L14-19]
-    new_nis_counter = jax.lax.select(any_improvement, 0, nis_counter)
+    new_nis_counter = jax.numpy.where(any_improvement, 0, nis_counter)
     reset_criterion = jnp.logical_and(any_improvement, c_mult < 1)
-    c_mult = jax.lax.select(reset_criterion, 1.0, c_mult)
+    c_mult = jax.numpy.where(reset_criterion, 1.0, c_mult)
     sdr_criterion = jnp.logical_and(any_improvement, sdr > theta_sdr)
-    c_mult_inc = jax.lax.select(sdr_criterion, eta_avs_inc * c_mult, c_mult)
+    c_mult_inc = jax.numpy.where(sdr_criterion, eta_avs_inc * c_mult, c_mult)
 
     # Case 2: If  no improvement in best fitness -> Decrease c_mult! [L21-24]
     nis_dec_criterion = jnp.logical_and(1 - any_improvement, c_mult <= 1)
-    new_nis_counter = jax.lax.select(
+    new_nis_counter = jax.numpy.where(
         nis_dec_criterion, nis_counter + 1, new_nis_counter
     )
     dec_criterion = jnp.logical_and(
         1 - any_improvement,
         jnp.logical_or(c_mult > 1, new_nis_counter >= nis_max_gens),
     )
-    c_mult_dec = jax.lax.select(dec_criterion, eta_avs_dec * c_mult, c_mult)
+    c_mult_dec = jax.numpy.where(dec_criterion, eta_avs_dec * c_mult, c_mult)
     c_dec_criterion = jnp.logical_and(
         1 - any_improvement, new_nis_counter < nis_max_gens
     )
     c_dec_reset_criterion = jnp.logical_and(c_dec_criterion, c_mult_dec < 1)
-    c_mult_dec = jax.lax.select(c_dec_reset_criterion, 1.0, c_mult_dec)
+    c_mult_dec = jax.numpy.where(c_dec_reset_criterion, 1.0, c_mult_dec)
 
     # Select new multiplier based on case at hand
-    new_c_mult = jax.lax.select(any_improvement, c_mult_inc, c_mult_dec)
+    new_c_mult = jax.numpy.where(any_improvement, c_mult_inc, c_mult_dec)
     return new_c_mult, new_nis_counter
 
 

--- a/evosax/strategies/gesmr_ga.py
+++ b/evosax/strategies/gesmr_ga.py
@@ -168,7 +168,7 @@ class GESMR_GA(Strategy):
 
         # Set mean to best member seen so far
         improved = fitness[0] < state.best_fitness
-        best_mean = jax.lax.select(improved, archive[0], state.best_member)
+        best_mean = jax.numpy.where(improved, archive[0], state.best_member)
         return state.replace(
             rng=rng,
             fitness=fitness[idx],

--- a/evosax/strategies/lga.py
+++ b/evosax/strategies/lga.py
@@ -183,7 +183,7 @@ class LGA(Strategy):
 
         # Argsort by performance and set mean
         improved = fit_all[idx][0] < state.best_fitness
-        best_mean = jax.lax.select(improved, x_all[idx][0], state.best_member)
+        best_mean = jax.numpy.where(improved, x_all[idx][0], state.best_member)
         return state.replace(
             rng=rng_next,
             mean=best_mean,

--- a/evosax/strategies/lm_ma_es.py
+++ b/evosax/strategies/lm_ma_es.py
@@ -286,7 +286,7 @@ def sample(
         new_z = (1 - c_d[j]) * z + (c_d[j] * M[:, j])[:, jnp.newaxis] * (
             M[:, j][:, jnp.newaxis] * z
         )
-        z = jax.lax.select(update_bool, new_z, z)
+        z = jax.numpy.where(update_bool, new_z, z)
     z = jnp.swapaxes(z, 1, 0)
     x = mean + sigma * z  # ~ N(m, σ^2 C)
     return x

--- a/evosax/strategies/mr15_ga.py
+++ b/evosax/strategies/mr15_ga.py
@@ -135,12 +135,12 @@ class MR15_GA(Strategy):
         # Update mutation sigma - double if more than 15% improved
         good_mutations_ratio = jnp.mean(fitness < state.best_fitness)
         increase_sigma = good_mutations_ratio > params.sigma_ratio
-        sigma = jax.lax.select(
+        sigma = jax.numpy.where(
             increase_sigma, 2 * state.sigma, 0.5 * state.sigma
         )
         # Set mean to best member seen so far
         improved = fitness[0] < state.best_fitness
-        best_mean = jax.lax.select(improved, archive[0], state.best_member)
+        best_mean = jax.numpy.where(improved, archive[0], state.best_member)
         return state.replace(
             fitness=fitness, archive=archive, sigma=sigma, mean=best_mean
         )

--- a/evosax/strategies/noise_reuse_es.py
+++ b/evosax/strategies/noise_reuse_es.py
@@ -121,7 +121,7 @@ class NoiseReuseES(Strategy):
         )
         neg_perts = -pos_perts
         perts = jnp.concatenate([pos_perts, neg_perts], axis=0)
-        unroll_pert = jax.lax.select(
+        unroll_pert = jax.numpy.where(
             state.inner_step_counter == 0, perts, state.unroll_pert
         )
         # Add the perturbations from this unroll to the perturbation accumulators
@@ -150,7 +150,7 @@ class NoiseReuseES(Strategy):
         sigma = exp_decay(state.sigma, params.sigma_decay, params.sigma_limit)
         # Resample antithetic noise if done with inner problem
         reset = inner_step_counter >= params.T
-        inner_step_counter = jax.lax.select(reset, 0, inner_step_counter)
+        inner_step_counter = jax.numpy.where(reset, 0, inner_step_counter)
         return state.replace(
             mean=mean,
             sigma=sigma,

--- a/evosax/strategies/pbt.py
+++ b/evosax/strategies/pbt.py
@@ -117,7 +117,7 @@ def single_member_exploit(
     """Get the top and bottom performers."""
     best_id = jnp.argmax(fitness)
     exploit_bool = member_id != best_id  # Copy if worker not best
-    copy_id = jax.lax.select(exploit_bool, best_id, member_id)
+    copy_id = jax.numpy.where(exploit_bool, best_id, member_id)
     hyperparams_copy = archive[copy_id]
     return exploit_bool, copy_id, hyperparams_copy
 
@@ -132,7 +132,7 @@ def single_member_explore(
     explore_noise = (
         jax.random.normal(rng, hyperparams.shape) * params.noise_scale
     )
-    hyperparams_explore = jax.lax.select(
+    hyperparams_explore = jax.numpy.where(
         exploit_bool, hyperparams + explore_noise, hyperparams
     )
     return hyperparams_explore

--- a/evosax/strategies/persistent_es.py
+++ b/evosax/strategies/persistent_es.py
@@ -148,8 +148,8 @@ class PersistentES(Strategy):
         sigma = exp_decay(state.sigma, params.sigma_decay, params.sigma_limit)
         # Reset accumulated antithetic noise memory if done with inner problem
         reset = inner_step_counter >= params.T
-        inner_step_counter = jax.lax.select(reset, 0, inner_step_counter)
-        pert_accum = jax.lax.select(
+        inner_step_counter = jax.numpy.where(reset, 0, inner_step_counter)
+        pert_accum = jax.numpy.where(
             reset, jnp.zeros((self.popsize, self.num_dims)), state.pert_accum
         )
         return state.replace(

--- a/evosax/strategies/random.py
+++ b/evosax/strategies/random.py
@@ -90,5 +90,5 @@ class RandomSearch(Strategy):
         x = x[idx]
         # Set mean to best member seen so far
         improved = fitness[0] < state.best_fitness
-        best_mean = jax.lax.select(improved, x[0], state.best_member)
+        best_mean = jax.numpy.where(improved, x[0], state.best_member)
         return state.replace(mean=best_mean)

--- a/evosax/strategies/rm_es.py
+++ b/evosax/strategies/rm_es.py
@@ -256,15 +256,15 @@ def update_P_matrix(
     i_min = jnp.argmin(t_gap[:-1] - t_gap[1:])
     for i in range(memory_size - 1):
         replace_bool = i >= i_min
-        P_c2 = jax.lax.select(
+        P_c2 = jax.numpy.where(
             replace_bool, P_c2.at[:, i].set(P_c2[:, i + 1]), P_c2
         )
-        t_gap_c2 = jax.lax.select(
+        t_gap_c2 = jax.numpy.where(
             replace_bool, t_gap_c2.at[i].set(t_gap_c2[i + 1]), t_gap_c2
         )
 
-    P = jax.lax.select(push_replace, P_c1, P_c2)
-    t_gap = jax.lax.select(push_replace, t_gap_c1, t_gap_c2)
+    P = jax.numpy.where(push_replace, P_c1, P_c2)
+    t_gap = jax.numpy.where(push_replace, t_gap_c1, t_gap_c2)
 
     # Finally update with the most recent evolution path
     P = P.at[:, memory_size - 1].set(p_sigma)
@@ -299,7 +299,7 @@ def sample(
             + (jnp.sqrt(c_cov) * P[:, j])[:, jnp.newaxis]
             * r[:, j][:, jnp.newaxis]
         )
-        z = jax.lax.select(update_bool, new_z, z)
+        z = jax.numpy.where(update_bool, new_z, z)
     z = jnp.swapaxes(z, 1, 0)
     x = mean + sigma * z  # ~ N(m, σ^2 C)
     return x

--- a/evosax/strategies/samr_ga.py
+++ b/evosax/strategies/samr_ga.py
@@ -117,7 +117,7 @@ class SAMR_GA(Strategy):
 
         # Set mean to best member seen so far
         improved = fitness[0] < state.best_fitness
-        best_mean = jax.lax.select(improved, archive[0], state.best_member)
+        best_mean = jax.numpy.where(improved, archive[0], state.best_member)
         return state.replace(
             fitness=fitness, archive=archive, sigma=sigma, mean=best_mean
         )

--- a/evosax/strategies/sim_anneal.py
+++ b/evosax/strategies/sim_anneal.py
@@ -124,16 +124,16 @@ class SimAnneal(Strategy):
         # Replace mean either if improvement or random metropolis acceptance
         rand_replace = jnp.logical_or(improved, state.replace_rng > metropolis)
         # Note: We replace by best member in generation (not completely random)
-        mean = jax.lax.select(rand_replace, gen_member, state.mean)
+        mean = jax.numpy.where(rand_replace, gen_member, state.mean)
 
         # Update permutation standard deviation
-        sigma = jax.lax.select(
+        sigma = jax.numpy.where(
             state.sigma > params.sigma_limit,
             state.sigma * params.sigma_decay,
             state.sigma,
         )
 
-        temp = jax.lax.select(
+        temp = jax.numpy.where(
             state.temp > params.temp_limit,
             state.temp * params.temp_decay,
             state.temp,

--- a/evosax/strategies/simple_ga.py
+++ b/evosax/strategies/simple_ga.py
@@ -141,7 +141,7 @@ class SimpleGA(Strategy):
         sigma = exp_decay(state.sigma, params.sigma_decay, params.sigma_limit)
         # Set mean to best member seen so far
         improved = fitness[0] < state.best_fitness
-        best_mean = jax.lax.select(improved, archive[0], state.best_member)
+        best_mean = jax.numpy.where(improved, archive[0], state.best_member)
         return state.replace(
             fitness=fitness, archive=archive, sigma=sigma, mean=best_mean
         )

--- a/evosax/strategies/snes.py
+++ b/evosax/strategies/snes.py
@@ -102,7 +102,7 @@ class SNES(Strategy):
             maxval=params.init_max,
         )
         use_des_weights = params.temperature > 0.0
-        weights = jax.lax.select(
+        weights = jax.numpy.where(
             use_des_weights,
             get_temp_weights(self.popsize, params.temperature),
             get_recombination_weights(self.popsize),

--- a/evosax/strategies/xnes.py
+++ b/evosax/strategies/xnes.py
@@ -153,7 +153,7 @@ class xNES(Strategy):
             params.c_prime,
             params.rho,
         )
-        lrate_sigma = jax.lax.select(
+        lrate_sigma = jax.numpy.where(
             params.use_adasam, lrate_sigma, state.lrate_sigma
         )
         return state.replace(
@@ -194,7 +194,7 @@ def adaptation_sampling(
     )
 
     # Check test significance and update lrate
-    lrate_sigma = jax.lax.select(
+    lrate_sigma = jax.numpy.where(
         cumulative < rho,
         (1 - c_prime) * lrate_sigma + c_prime * lrate_sigma_init,
         jnp.minimum(1, (1 - c_prime) * lrate_sigma),

--- a/evosax/utils/helpers.py
+++ b/evosax/utils/helpers.py
@@ -8,9 +8,9 @@ def get_best_fitness_member(
     x: chex.Array, fitness: chex.Array, state, maximize: bool = False
 ) -> Tuple[chex.Array, float]:
     """Check if fitness improved & replace in ES state."""
-    fitness_min = jax.lax.select(maximize, -1 * fitness, fitness)
+    fitness_min = jax.numpy.where(maximize, -1 * fitness, fitness)
     max_and_later = maximize and state.gen_counter > 0
-    best_fit_min = jax.lax.select(
+    best_fit_min = jax.numpy.where(
         max_and_later, -1 * state.best_fitness, state.best_fitness
     )
     best_in_gen = jnp.argmin(fitness_min)
@@ -19,11 +19,11 @@ def get_best_fitness_member(
         x[best_in_gen],
     )
     replace_best = best_in_gen_fitness < best_fit_min
-    best_fitness = jax.lax.select(
+    best_fitness = jax.numpy.where(
         replace_best, best_in_gen_fitness, best_fit_min
     )
-    best_member = jax.lax.select(
+    best_member = jax.numpy.where(
         replace_best, best_in_gen_member, state.best_member
     )
-    best_fitness = jax.lax.select(maximize, -1 * best_fitness, best_fitness)
+    best_fitness = jax.numpy.where(maximize, -1 * best_fitness, best_fitness)
     return best_member, best_fitness


### PR DESCRIPTION
Fixes https://github.com/RobertTLange/evosax/issues/45#issuecomment-1528573782. See also the [jax.lax docs](https://jax.readthedocs.io/en/latest/jax.lax.html):

> Where possible, prefer to use libraries such as [jax.numpy](https://jax.readthedocs.io/en/latest/jax.numpy.html#module-jax.numpy) instead of using [jax.lax](https://jax.readthedocs.io/en/latest/jax.lax.html#module-jax.lax) directly. The [jax.numpy](https://jax.readthedocs.io/en/latest/jax.numpy.html#module-jax.numpy) API follows NumPy, and is therefore more stable and less likely to change than the [jax.lax](https://jax.readthedocs.io/en/latest/jax.lax.html#module-jax.lax) API.