### PR TITLE
Small improvements to the CMA-ES implementation

### DIFF
--- a/evosax/strategies/cma_es.py
+++ b/evosax/strategies/cma_es.py
@@ -345,9 +345,7 @@ def update_covariance(
     )
     delta_h_sigma = (1 - h_sigma) * c_c * (2 - c_c)
     rank_one = jnp.outer(p_c, p_c)
-    rank_mu = jnp.sum(
-        jnp.array([w * jnp.outer(y, y) for w, y in zip(w_io, y_k)]), axis=0
-    )
+    rank_mu = jnp.einsum('i,ij,ik->jk', w_io, y_k, y_k)
     C = (
         (1 + c_1 * delta_h_sigma - c_1 - c_mu * jnp.sum(weights)) * C
         + c_1 * rank_one

--- a/evosax/strategies/sep_cma_es.py
+++ b/evosax/strategies/sep_cma_es.py
@@ -299,10 +299,7 @@ def update_covariance(
     """Update cov. matrix estimator using rank 1 + μ updates."""
     delta_h_sigma = (1 - h_sigma) * c_c * (2 - c_c)
     rank_one = p_c**2
-    rank_mu = jnp.sum(
-        jnp.array([w * (y**2) for w, y in zip(weights, y_k)]),
-        axis=0,
-    )
+    rank_mu = jnp.einsum('i,ij->j', weights, y_k**2)
     C = (
         (1 + c_1 * delta_h_sigma - c_1 - c_mu * jnp.sum(weights)) * C
         + c_1 * rank_one

--- a/evosax/strategies/sep_cma_es.py
+++ b/evosax/strategies/sep_cma_es.py
@@ -209,7 +209,7 @@ class Sep_CMA_ES(Strategy):
             state.C,
             y_k,
             h_sigma,
-            state.weights,
+            state.weights_truncated,
             params.c_c,
             params.c_1,
             params.c_mu,
@@ -291,7 +291,7 @@ def update_covariance(
     C: chex.Array,
     y_k: chex.Array,
     h_sigma: float,
-    weights: chex.Array,
+    weights_truncated: chex.Array,
     c_c: float,
     c_1: float,
     c_mu: float,
@@ -299,9 +299,9 @@ def update_covariance(
     """Update cov. matrix estimator using rank 1 + μ updates."""
     delta_h_sigma = (1 - h_sigma) * c_c * (2 - c_c)
     rank_one = p_c**2
-    rank_mu = jnp.einsum('i,ij->j', weights, y_k**2)
+    rank_mu = jnp.einsum('i,ij->j', weights_truncated, y_k**2)
     C = (
-        (1 + c_1 * delta_h_sigma - c_1 - c_mu * jnp.sum(weights)) * C
+        (1 + c_1 * delta_h_sigma - c_1 - c_mu * jnp.sum(weights_truncated)) * C
         + c_1 * rank_one
         + c_mu * rank_mu
     )

--- a/evosax/utils/eigen_decomp.py
+++ b/evosax/utils/eigen_decomp.py
@@ -12,7 +12,7 @@ def full_eigen_decomp(
     C = C + 1e-10 * (gen_counter == 0)
     C = (C + C.T) / 2  # Make sure matrix is symmetric
     D2, B = jnp.linalg.eigh(C)
-    D = jnp.sqrt(jnp.where(D2 < 0, 1e-20, D2))
+    D = jnp.sqrt(jnp.where(D2 <= 0, 1e-20, D2))
     C = jnp.dot(jnp.dot(B, jnp.diag(D ** 2)), B.T)
     return C, B, D
 
@@ -21,5 +21,5 @@ def diag_eigen_decomp(C: chex.Array, D: chex.Array) -> chex.Array:
     """Perform simplified decomposition of diagonal covariance matrix."""
     if D is not None:
         return D
-    D = jnp.sqrt(jnp.where(C < 0, 1e-20, C))
+    D = jnp.sqrt(jnp.where(C <= 0, 1e-20, C))
     return D


### PR DESCRIPTION
Thanks for maintaining this awesome repo :) 

Two very small changes for CMA-ES:

1) Clip all eigenvalues of C in D to be >= 0 to avoid numerical underflow. Otherwise, this edge-case currently caused errors, as C_2 is computed by inverting D. It seems this was already partially covered for D < 0 (i.e., when numerical underflow in eigh would yield -0.0 as opposed to 0, which I believe is down to chance).

2) Convert for loops within list comprehensions for covariance computation into single einsum operations for efficiency.