### PR TITLE
Make eigenvalue decomposition numerically stable

### DIFF
--- a/evosax/restarts/termination.py
+++ b/evosax/restarts/termination.py
@@ -39,7 +39,6 @@ def cma_criterion(
         state.strategy_state.C,
         state.strategy_state.B,
         state.strategy_state.D,
-        state.strategy_state.gen_counter,
     )
 
     # Stop if std of normal distrib is smaller than tolx in all coordinates

--- a/evosax/strategies/cma_es.py
+++ b/evosax/strategies/cma_es.py
@@ -172,9 +172,7 @@ class CMA_ES(Strategy):
         self, rng: chex.PRNGKey, state: EvoState, params: EvoParams
     ) -> Tuple[chex.Array, EvoState]:
         """`ask` for new parameter candidates to evaluate next."""
-        C, B, D = full_eigen_decomp(
-            state.C, state.B, state.D, state.gen_counter
-        )
+        C, B, D = full_eigen_decomp(state.C, state.B, state.D)
         x = sample(
             rng,
             state.mean,
@@ -280,7 +278,7 @@ def update_p_sigma(
     gen_counter: int,
 ) -> Tuple[chex.Array, chex.Array, chex.Array, None, None]:
     """Update evolution path for covariance matrix."""
-    C, B, D = full_eigen_decomp(C, B, D, gen_counter)
+    C, B, D = full_eigen_decomp(C, B, D)
     C_2 = B.dot(jnp.diag(1 / D)).dot(B.T)  # C^(-1/2) = B D^(-1) B^T
     p_sigma_new = (1 - c_sigma) * p_sigma + jnp.sqrt(
         c_sigma * (2 - c_sigma) * mu_eff


### PR DESCRIPTION
### Description:

Fixed numerical instability in CMA-ES eigendecomposition that caused divergent behavior between different GPU architectures (H100 vs A100). Changes include:

- Reordered diagonal loading and symmetrization operations
- Increased epsilon value for float32 stability
- Removed unnecessary covariance matrix reconstruction

### Testing:

Verified identical results between H100 and A100 runs