### PR TITLE
Updates for compatibility in RL tutorial with JAX v0.6.0

### DIFF
--- a/evosax/problems/rl/brax.py
+++ b/evosax/problems/rl/brax.py
@@ -101,9 +101,9 @@ class BraxProblem(Problem):
 
         return State(
             counter=0,
-            obs_mean=jax.tree_map(lambda x: jnp.zeros_like(x), dummy_env_state.obs),
-            obs_std=jax.tree_map(lambda x: jnp.ones_like(x), dummy_env_state.obs),
-            obs_var_sum=jax.tree_map(lambda x: jnp.zeros_like(x), dummy_env_state.obs),
+            obs_mean=jax.tree.map(lambda x: jnp.zeros_like(x), dummy_env_state.obs),
+            obs_std=jax.tree.map(lambda x: jnp.ones_like(x), dummy_env_state.obs),
+            obs_var_sum=jax.tree.map(lambda x: jnp.zeros_like(x), dummy_env_state.obs),
             obs_counter=0,
             std_min=1e-6,
             std_max=1e6,
@@ -175,7 +175,7 @@ class BraxProblem(Problem):
 
     def normalize_obs(self, obs: PyTree, state: State) -> PyTree:
         """Normalize observations using running statistics."""
-        return jax.tree_map(
+        return jax.tree.map(
             lambda obs, mean, std: (obs - mean) / std,
             obs,
             state.obs_mean,

--- a/evosax/problems/rl/gymnax.py
+++ b/evosax/problems/rl/gymnax.py
@@ -112,9 +112,9 @@ class GymnaxProblem(Problem):
 
         return State(
             counter=0,
-            obs_mean=jax.tree_map(lambda x: jnp.zeros_like(x), dummy_obs),
-            obs_std=jax.tree_map(lambda x: jnp.ones_like(x), dummy_obs),
-            obs_var_sum=jax.tree_map(lambda x: jnp.zeros_like(x), dummy_obs),
+            obs_mean=jax.tree.map(lambda x: jnp.zeros_like(x), dummy_obs),
+            obs_std=jax.tree.map(lambda x: jnp.ones_like(x), dummy_obs),
+            obs_var_sum=jax.tree.map(lambda x: jnp.zeros_like(x), dummy_obs),
             obs_counter=0,
             std_min=1e-6,
             std_max=1e6,
@@ -189,7 +189,7 @@ class GymnaxProblem(Problem):
 
     def normalize_obs(self, obs: PyTree, state: State) -> PyTree:
         """Normalize observations using running statistics."""
-        return jax.tree_map(
+        return jax.tree.map(
             lambda obs, mean, std: (obs - mean) / std,
             obs,
             state.obs_mean,
@@ -232,7 +232,7 @@ class GymnaxProblem(Problem):
             return new_obs_mean, new_obs_var_sum
 
         # Apply the update function to each leaf in the observation PyTree
-        obs_mean, obs_var_sum = jax.tree_map(
+        obs_mean, obs_var_sum = jax.tree.map(
             lambda obs, mean, var: _update_leaf_stats(obs, mean, var),
             obs,
             state.obs_mean,


### PR DESCRIPTION
While running the example notebook `examples/02_rl.ipynb`, I encountered an error due to the removal of jax.tree_map in JAX v0.6.0. I replaced calls to `jax.tree_map` with `jax.tree.map`

The cell where I had the error:
```python
from evosax.problems import BraxProblem as Problem
from evosax.problems.networks import MLP, tanh_output_fn

policy = MLP(
    layer_sizes=(32, 32, 32, 32, 8),
    output_fn=tanh_output_fn,
)

problem = Problem(
    env_name="ant",
    policy=policy,
    episode_length=1000,
    num_rollouts=16,
    use_normalize_obs=True,
)

key, subkey = jax.random.split(key)
problem_state = problem.init(key)

key, subkey = jax.random.split(key)
solution = problem.sample(subkey)
```


The error:
```
AttributeError: jax.tree_map was removed in JAX v0.6.0: use jax.tree.map (jax v0.4.25 or newer) or jax.tree_util.tree_map (any JAX version).
```

