### PR TITLE
Fix jax dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "evosax"
 version = "0.2.0"
 dependencies = [
 	"numpy>=1.25",
-	"jax>=0.5.0",
+	"jax>=0.5.0,<0.6.0",
 	"flax>=0.10.0",
 	"dotmap",
 	"matplotlib",


### PR DESCRIPTION
Hello (again),

Currently your `pyproject.toml` claims to support jax>=0.5.0, but this is incorrect since 0.6.0, that has deprecated `jax.tree_map`. Downloading the current dependencies and running basically anything results in:

`AttributeError: jax.tree_map was removed in JAX v0.6.0: use jax.tree.map (jax v0.4.25 or newer) or jax.tree_util.tree_map (any JAX version). `

I changed the `pyproject.toml` to specify JAX<0.6.0.