### PR TITLE
Add fitness standard deviation restart condition

### DIFF
--- a/evosax/core/restart.py
+++ b/evosax/core/restart.py
@@ -18,6 +18,12 @@ class RestartParams:
     pass
 
 
+@struct.dataclass
+class FitnessStdRestartParams(RestartParams):
+    tol: float = 0.001
+    atol: float = 0.0
+
+
 def generation_cond(
     population: Population,
     fitness: Fitness,
@@ -40,6 +46,20 @@ def spread_cond(
 ) -> bool:
     """Stop if fitness max minus fitness min is below threshold."""
     return jnp.max(fitness) - jnp.min(fitness) < restart_params.fitness_spread_threshold
+
+
+def fitness_std_cond(
+    population: Population,
+    fitness: Fitness,
+    state: State,
+    params: Params,
+    restart_state: RestartState,
+    restart_params: FitnessStdRestartParams,
+) -> bool:
+    """Stop if fitness standard deviation is below tolerance."""
+    finite = jnp.all(jnp.isfinite(fitness))
+    threshold = restart_params.atol + restart_params.tol * jnp.abs(jnp.mean(fitness))
+    return jnp.logical_and(finite, jnp.std(fitness) <= threshold)
 
 
 def cma_cond(

--- a/tests/test_core/test_restart.py
+++ b/tests/test_core/test_restart.py
@@ -35,9 +35,9 @@ def test_fitness_std_cond_absolute_tolerance():
     assert bool(converged)
 
 
-def test_fitness_std_cond_nonfinite_not_converged():
-    """Test non-finite fitness values do not converge."""
-    fitness = jnp.array([1.0, 1.0, jnp.nan])
+def test_fitness_std_cond_infinite_not_converged():
+    """Test infinite fitness values do not converge."""
+    fitness = jnp.array([1.0, 1.0, jnp.inf])
     restart_params = FitnessStdRestartParams(tol=0.001)
 
     converged = fitness_std_cond(None, fitness, None, None, None, restart_params)

--- a/tests/test_core/test_restart.py
+++ b/tests/test_core/test_restart.py
@@ -1,0 +1,58 @@
+"""Tests for restart condition functions."""
+
+import jax
+import jax.numpy as jnp
+from evosax.core.restart import FitnessStdRestartParams, fitness_std_cond
+
+
+def test_fitness_std_cond_relative_tolerance_converges():
+    """Test convergence using relative tolerance."""
+    fitness = jnp.array([999.9, 1000.0, 1000.1])
+    restart_params = FitnessStdRestartParams(tol=0.001)
+
+    converged = fitness_std_cond(None, fitness, None, None, None, restart_params)
+
+    assert bool(converged)
+
+
+def test_fitness_std_cond_relative_tolerance_not_converged():
+    """Test non-convergence when fitness spread is too large."""
+    fitness = jnp.array([990.0, 1000.0, 1010.0])
+    restart_params = FitnessStdRestartParams(tol=0.001)
+
+    converged = fitness_std_cond(None, fitness, None, None, None, restart_params)
+
+    assert not bool(converged)
+
+
+def test_fitness_std_cond_absolute_tolerance():
+    """Test convergence near zero mean using absolute tolerance."""
+    fitness = jnp.array([-0.05, 0.0, 0.05])
+    restart_params = FitnessStdRestartParams(tol=0.0, atol=0.1)
+
+    converged = fitness_std_cond(None, fitness, None, None, None, restart_params)
+
+    assert bool(converged)
+
+
+def test_fitness_std_cond_nonfinite_not_converged():
+    """Test non-finite fitness values do not converge."""
+    fitness = jnp.array([1.0, 1.0, jnp.nan])
+    restart_params = FitnessStdRestartParams(tol=0.001)
+
+    converged = fitness_std_cond(None, fitness, None, None, None, restart_params)
+
+    assert not bool(converged)
+
+
+def test_fitness_std_cond_jit():
+    """Test condition is compatible with JIT."""
+    restart_params = FitnessStdRestartParams(tol=0.001)
+
+    @jax.jit
+    def is_converged(fitness):
+        return fitness_std_cond(None, fitness, None, None, None, restart_params)
+
+    fitness = jnp.array([999.9, 1000.0, 1000.1])
+
+    assert bool(is_converged(fitness))


### PR DESCRIPTION
Thanks for maintaining `evosax`!

SciPy's `differential_evolution` supports early stopping based on the standard deviation of the current population fitness values:

```python
std(fitness) <= atol + tol * abs(mean(fitness))
```

This lets callers set a conservative maximum generation budget while still allowing easier runs to exit once the population has converged in objective value. I've found this same stopping rule useful for performance in my own work with `evosax`.

`evosax` already has restart-condition utilities in `evosax.core.restart`, and users often compose their own `ask`/`tell` loops. I thought this rule fit naturally as another small reusable predicate in that module, so this PR adds `FitnessStdRestartParams(tol=0.001, atol=0.0)` and `fitness_std_cond(...)`.

The predicate returns `False` if any fitness value is non-finite; otherwise it applies the `atol + tol * abs(mean(fitness))` threshold. I kept this intentionally narrow: no runner abstraction and no algorithm API changes. Let me know if you would prefer a different name or location for this utility.

I added restart tests for tolerance behavior, non-finite fitness values, and JIT compatibility. ruff and the full pytest tests/ suite pass locally.