### PR TITLE
Fix LM-MA-ES int32 overflow in cumulative learning rates

### DIFF
--- a/evosax/algorithms/distribution_based/lm_ma_es.py
+++ b/evosax/algorithms/distribution_based/lm_ma_es.py
@@ -53,8 +53,9 @@ class LM_MA_ES(MA_ES):
         parent_params = super()._default_params
 
         # Override or add LM-MA-ES specific parameters
-        c_d = 1 / jnp.power(1.5, jnp.arange(self.m)) / self.num_dims
-        c_c = self.population_size / jnp.power(4.0, jnp.arange(self.m)) / self.num_dims
+        indices = jnp.arange(self.m, dtype=jnp.float32)
+        c_d = 1 / jnp.power(1.5, indices) / self.num_dims
+        c_c = self.population_size / jnp.power(4.0, indices) / self.num_dims
 
         # Set c_1 and c_mu to 0 as they're not used in LM-MA-ES
         return Params(


### PR DESCRIPTION
This PR addresses a strange bug in LM-MA-ES implementation. I found `c_c = population_size / jnp.power(4, jnp.arange(self.m)) / num_dims` at the line 56 causes overflow to zero. Because 4 and `jnp.arange` are integers, JAX uses int32. Let index be 16, $4^{16} = 2^{32}$ which overflows to zero.
To fix this issue, I replaced indices with factoring `float32` indices for computing `c_c` and `c_d`. This prevents int32 overflow at index 16.