### PR TITLE
Fix SV_Open_ES missing params for Optax weight decay

### DIFF
--- a/evosax/algorithms/distribution_based/sv/sv_open_es.py
+++ b/evosax/algorithms/distribution_based/sv/sv_open_es.py
@@ -89,7 +89,9 @@ class SV_Open_ES(SV_ES, Open_ES):
         grad = -(svgd_grad + params.alpha * svgd_grad_kernel)
 
         # Update mean
-        updates, opt_state = jax.vmap(self.optimizer.update)(grad, state.opt_state)
+        updates, opt_state = jax.vmap(self.optimizer.update)(
+            grad, state.opt_state, state.mean
+        )
         mean = jax.vmap(optax.apply_updates)(state.mean, updates)
 
         return state.replace(mean=mean, opt_state=opt_state)

--- a/tests/test_algorithms/test_distribution_based.py
+++ b/tests/test_algorithms/test_distribution_based.py
@@ -3,7 +3,11 @@
 import jax
 import jax.numpy as jnp
 import optax
-from evosax.algorithms.distribution_based import Open_ES, distribution_based_algorithms
+from evosax.algorithms.distribution_based import (
+    Open_ES,
+    SV_Open_ES,
+    distribution_based_algorithms,
+)
 
 
 def test_run(
@@ -230,3 +234,34 @@ def test_open_es_runs_with_adamw_optimizer(key, population_size, bbob_problem):
 
     assert jnp.all(jnp.isfinite(state.mean))
     assert jnp.isfinite(metrics["best_fitness"])
+
+
+def test_sv_open_es_runs_with_adamw_optimizer(key, population_size, bbob_problem):
+    """SV_Open_ES should pass mean into optimizers that require params (e.g. adamw)."""
+    num_populations = 2
+    solution = bbob_problem.sample(key)
+    algo = SV_Open_ES(
+        population_size=population_size,
+        num_populations=num_populations,
+        solution=solution,
+        optimizer=optax.adamw(learning_rate=1e-3, weight_decay=1e-4),
+    )
+    params = algo.default_params
+
+    key, subkey = jax.random.split(key)
+    keys = jax.random.split(subkey, num_populations)
+    mean_init = jax.vmap(bbob_problem.sample)(keys)
+
+    key, subkey = jax.random.split(key)
+    state = algo.init(subkey, mean_init, params)
+
+    key, subkey = jax.random.split(key)
+    problem_state = bbob_problem.init(subkey)
+
+    key, key_ask, key_tell = jax.random.split(key, 3)
+    population, state = algo.ask(key_ask, state, params)
+    fitness, problem_state, _ = bbob_problem.eval(key_tell, population, problem_state)
+    state, metrics = algo.tell(key_tell, population, fitness, state, params)
+
+    assert jnp.all(jnp.isfinite(state.mean))
+    assert jnp.all(jnp.isfinite(metrics["best_fitness"]))


### PR DESCRIPTION
This PR addresses a problem in SV_Open_ES. Optax optimizers with weight decay (e.g. `adamw`) need the current params in `optimizer.update`, which in evosax is the mean vector. Most distribution-based algorithms already pass `state.mean` after #99, but `SV_Open_ES` still called `jax.vmap(self.optimizer.update)(grad, state.opt_state)` without it. That raises:

`ValueError: You are using a transformation that requires the current value of parameters, but you are not passing params when calling update.`

To fix this issue, I pass `state.mean` into the vmapped optimizer update, and add a regression test with `optax.adamw`.