### PR TITLE
Fix population-based archive init and PSO personal/global best seeding

### DIFF
--- a/evosax/algorithms/population_based/base.py
+++ b/evosax/algorithms/population_based/base.py
@@ -56,12 +56,19 @@ class PopulationBasedAlgorithm(EvolutionaryAlgorithm):
         # Ravel population
         population = jax.vmap(self._ravel_solution)(population)
 
+        # Seed archive from the evaluated initial population (raw fitness)
+        best_idx = jnp.argmin(fitness)
+        best_solution = population[best_idx]
+        best_fitness = fitness[best_idx]
+
         # Shape fitness
         fitness = self.fitness_shaping_fn(population, fitness, state, params)
 
         state = state.replace(
             population=population,
             fitness=fitness,
+            best_solution=best_solution,
+            best_fitness=best_fitness,
         )
         return state
 

--- a/evosax/algorithms/population_based/pso.py
+++ b/evosax/algorithms/population_based/pso.py
@@ -4,6 +4,7 @@
 """
 
 from collections.abc import Callable
+from functools import partial
 
 import jax
 import jax.numpy as jnp
@@ -70,24 +71,33 @@ class PSO(PopulationBasedAlgorithm):
         )
         return state
 
+    @partial(jax.jit, static_argnames=("self",))
+    def init(
+        self,
+        key: jax.Array,
+        population: Population,
+        fitness: Fitness,
+        params: Params,
+    ) -> State:
+        """Initialize PSO, seeding personal bests from the initial population."""
+        state = super().init(key, population, fitness, params)
+        return state.replace(
+            population_best=state.population,
+            fitness_best=state.fitness,
+        )
+
     def _ask(
         self,
         key: jax.Array,
         state: State,
         params: Params,
     ) -> tuple[Population, State]:
-        # Get global best
-        population_best = jnp.where(
-            jnp.isnan(state.population_best), state.population, state.population_best
-        )
-        fitness_best = jnp.where(
-            jnp.isnan(state.fitness_best), state.fitness, state.fitness_best
-        )
-        best_global_idx = jnp.argmin(fitness_best)
-        best_global = population_best[best_global_idx]
+        # Get global best from personal bests (seeded at init)
+        best_global_idx = jnp.argmin(state.fitness_best)
+        best_global = state.population_best[best_global_idx]
 
         def _ask_velocity(key, velocity, member, member_best):
-            # Sharing r1, r1 across dimensions seems more robust
+            # Sharing r1, r2 across dimensions seems more robust
             r1, r2 = jax.random.uniform(key, (2,))
             return (
                 params.inertia_coeff * velocity
@@ -98,7 +108,7 @@ class PSO(PopulationBasedAlgorithm):
         # Update particle positions with velocity
         keys = jax.random.split(key, self.population_size)
         velocity = jax.vmap(_ask_velocity)(
-            keys, state.velocity, state.population, population_best
+            keys, state.velocity, state.population, state.population_best
         )
         x = state.population + velocity
         return x, state.replace(velocity=velocity)

--- a/tests/test_algorithms/test_population_based.py
+++ b/tests/test_algorithms/test_population_based.py
@@ -3,6 +3,42 @@
 import jax
 import jax.numpy as jnp
 from evosax.algorithms.population_based import population_based_algorithms
+from evosax.algorithms.population_based.pso import PSO
+
+
+def test_pso_seeds_personal_and_global_best_from_init(key):
+    """PSO must keep the best initial particle after the first ask/tell."""
+    population_size = 3
+    num_dims = 1
+    algo = PSO(population_size=population_size, solution=jnp.zeros(num_dims))
+    params = algo.default_params
+
+    # True best at particle 2 (fitness 0); particle 0 is a distractor
+    population_init = jnp.array([[10.0], [20.0], [0.0]])
+    fitness_init = jnp.array([100.0, 400.0, 0.0])
+
+    key, subkey = jax.random.split(key)
+    state = algo.init(subkey, population_init, fitness_init, params)
+
+    assert jnp.allclose(state.population_best, population_init)
+    assert jnp.allclose(state.fitness_best, fitness_init)
+    assert jnp.allclose(state.best_solution, jnp.array([0.0]))
+    assert state.best_fitness == 0.0
+
+    # First ask must use true gbest (particle 2), not particle 0
+    key, key_ask, key_tell = jax.random.split(key, 3)
+    _, state = algo.ask(key_ask, state, params)
+
+    # Worse post-move positions (as under the old bogus-gbest pull)
+    population = jnp.array([[10.0], [10.57], [0.57]])
+    fitness = jnp.array([100.0, 105.7, 0.57])
+    state, _ = algo.tell(key_tell, population, fitness, state, params)
+
+    # Initial optimum must remain personal best for particle 2 and archive best
+    assert jnp.allclose(state.population_best[2], jnp.array([0.0]))
+    assert state.fitness_best[2] == 0.0
+    assert jnp.allclose(state.best_solution, jnp.array([0.0]))
+    assert state.best_fitness == 0.0
 
 
 def test_run(


### PR DESCRIPTION
This PR addresses an initialization gap in population-based algorithms. `PopulationBasedAlgorithm.init` only filled `population` / `fitness`, so archive `best_solution` / `best_fitness` stayed unset ($+\infty$ / NaN) until the first `tell`. That meant the evaluated initial population never entered the archive, the same family of init issue as in DE.

PSO makes this much worse. It also left `population_best` as NaN and `fitness_best` as $+\infty$. In `_ask`, the NaN fallback for positions worked, but the fitness fallback did not: `fitness_best` is $+\infty$, not NaN, so it never falls back to the current fitness. `argmin` over all $+\infty$ then always picks particle 0 as gbest. On the first `_tell`, `fitness <= state.fitness_best` is always true against $+\infty$, so personal bests are overwritten by the post-move positions and the evaluated initial population is never stored as pbest. Concretely, an init like fitness `[100, 400, 0]` can lose the zero solution on the first ask/tell as particle 2 is pulled toward the bogus gbest (particle 0).

To fix this, I seed archive `best_solution` / `best_fitness` from the initial eval in `PopulationBasedAlgorithm.init`, seed `population_best` / `fitness_best` from the initial population in `PSO.init`, and remove the broken NaN fallback in `_ask`. A regression test covers the init-best retention failure mode.